### PR TITLE
Handle `issue_closed` GitHub activity in renderText

### DIFF
--- a/components/contributors/GithubActivity.jsx
+++ b/components/contributors/GithubActivity.jsx
@@ -47,6 +47,7 @@ let renderText = (activity) => {
       );
     case "issue_opened":
     case "issue_assigned":
+    case "issue_closed":
       return (
         <div className="min-w-0 flex-1 py-1.5">
           <div className="text-sm text-gray-100">


### PR DESCRIPTION
Closes #14 

Before:
![image](https://user-images.githubusercontent.com/25143503/170849024-c9c761a9-67c4-4e68-86ac-9e7e1de9b254.png)

After:
![image](https://user-images.githubusercontent.com/25143503/170849031-15f2bd67-f8e1-4a4d-bfd7-c675595568ef.png)
