### PR TITLE
Fix leaderboard static date range

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,25 +11,26 @@ export const humanize = (str) => {
     });
 };
 
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "July",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
 export const parseDateString = (dateStr) => {
   const date = new Date(dateStr);
 
   if (date == "Invalid Date") return "";
 
-  const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "July",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
   let dateString = date.getDate() + " ";
   dateString += months[date.getMonth()] + " ";
   dateString += date.getFullYear() + " | ";
@@ -48,4 +49,20 @@ export const parseDateString = (dateStr) => {
     date.getMinutes() < 10 ? "0" + date.getMinutes() : date.getMinutes();
   dateString += date.getHours() > 11 ? " PM" : " AM";
   return dateString;
+};
+
+export const getLastWeekDateRangeString = () => {
+  let today = new Date();
+  let lastWeek = new Date(today);
+  lastWeek.setDate(today.getDate() - 7);
+
+  let start = String(lastWeek.getDate()).padStart(2, "0");
+  if (today.getMonth() !== lastWeek.getMonth()) {
+    start += ` ${months[lastWeek.getMonth()]}`;
+  }
+
+  let end = `${String(today.getDate()).padStart(2, "0")}`;
+  end += ` ${months[today.getMonth()]} ${today.getFullYear()}`;
+
+  return `${start} - ${end}`;
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import InfoCard from "../components/contributors/InfoCard";
 import Header from "../components/Header";
 import PageHead from "../components/PageHead";
 import { getContributors } from "../lib/api";
+import { getLastWeekDateRangeString } from "../lib/utils";
 
 export default function Home(props) {
   return (
@@ -77,7 +78,7 @@ export default function Home(props) {
                     <div className="flex justify-between items-end bg-gray-800 rounded-t-lg px-6 py-4 border-b border-gray-700 ">
                       <p className="text-xl font-medium">Leaderboard</p>
                       <span className="block text-gray-400">
-                        18 - 24 May 2022
+                        {props.dateRange}
                       </span>
                     </div>
                     <div className="space-y-2 p-4 ">
@@ -137,9 +138,12 @@ export default function Home(props) {
 
 export async function getStaticProps() {
   const contributors = getContributors();
+  const dateRange = getLastWeekDateRangeString();
+
   return {
     props: {
-      contributors: contributors,
+      contributors,
+      dateRange,
     },
   };
 }


### PR DESCRIPTION
Closes #71 

- When a week completely falls in the same month:
![image](https://user-images.githubusercontent.com/25143503/184890089-216525c0-27a4-410c-8db1-304f5ed6f4a7.png)

- When a week belongs to two months:
![image](https://user-images.githubusercontent.com/25143503/184890370-0c33484a-59bf-43b7-b6e1-117f276f93bf.png)
