### PR TITLE
UI enhancements for search, sort and toggle

### DIFF
--- a/components/filters/Filters.jsx
+++ b/components/filters/Filters.jsx
@@ -26,21 +26,21 @@ const Filters = ({
   ];
 
   return (
-    <div className="w-4/5 m-auto mt-4 p-4 border border-primary-500 rounded-lg">
+    <div className="mx-4 md:mx-0 mt-4 p-4 border border-primary-500 rounded-lg">
       <div className="flex flex-col md:flex-row justify-evenly items-center md:items-start gap-4">
         <Search
           value={searchTerm}
           handleOnChange={(e) => setSearchTerm(e.target.value)}
           className="w-full"
         />
-        <div className="w-full md:w-44 flex md:flex-col items-end justify-end gap-2">
+        <div className="w-full flex items-end justify-start gap-2">
           <Sort
             sortByOptions={sortParams}
             sortBy={sortBy}
             sortDescending={sortDescending}
             handleSortByChange={(e) => setSortBy(e.target.value)}
             handleSortOrderChange={() => setSortDescending((prev) => !prev)}
-            className="w-fit"
+            className="w-full"
           />
           <Tooltip
             tip={showCoreMembers ? "Hide Core Members" : "Show Core Members"}

--- a/components/filters/IconToggle.jsx
+++ b/components/filters/IconToggle.jsx
@@ -2,7 +2,7 @@ const IconToggle = ({ state = false, handleOnClick, TrueIcon, FalseIcon }) => {
   return (
     <div
       onClick={handleOnClick}
-      className="p-2 rounded border max-w-fit shadow-sm cursor-pointer"
+      className="p-2 rounded border shadow-sm cursor-pointer"
     >
       {state ? (
         <TrueIcon className="text-white" size={20} />

--- a/components/filters/Sort.jsx
+++ b/components/filters/Sort.jsx
@@ -10,7 +10,7 @@ const Sort = ({
 }) => {
   return (
     <div className={className}>
-      <span className="relative z-0 inline-flex shadow-sm rounded-md">
+      <span className="w-full relative z-0 inline-flex shadow-sm rounded-md">
         <span
           onClick={handleSortOrderChange}
           className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 cursor-pointer"
@@ -24,7 +24,7 @@ const Sort = ({
         <select
           id="message-type"
           name="message-type"
-          className="-ml-px block max-w-fit pl-2 rounded-l-none rounded-r-md border border-gray-300 text-sm font-medium focus:z-10 focus:outline-none bg-transparent text-white"
+          className="-ml-px block w-full pl-2 rounded-l-none rounded-r-md border border-gray-300 text-sm font-medium focus:z-10 focus:outline-none bg-transparent text-white"
           onChange={handleSortByChange}
         >
           {sortByOptions.map((option) => (

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -86,7 +86,7 @@ export default function Home(props) {
         <div className="border-gray-600 mx-4 xl:mx-0">
           <div className="lg:grid lg:grid-cols-12 lg:gap-12 2xl:gap-5 px-0 pb-10 lg:pb-20">
             <div className="lg:col-span-7 2xl:col-span-8">
-              <div className="sticky top-0 pt-24">
+              <div className="sticky top-0 pt-6">
                 <div className="terminal-container-bg border text-white rounded-lg border-primary-500">
                   <div className="flex space-x-2 px-6 py-3 border-b border-primary-500 ">
                     <span>


### PR DESCRIPTION
Closes #73

The following changes were made:

- Excess spacing between the search bar and live leaderboard is reduced

![image](https://user-images.githubusercontent.com/57593654/187252909-b41fd951-2b24-4e11-b592-ce383424a22c.png)

- Search sort and toggle are placed in a single row in desktop and left justified in mobile view

![image](https://user-images.githubusercontent.com/57593654/187253080-3db4be0f-bcae-4350-a0fe-21bc05e71738.png)
