### PR TITLE
fix: github avatars not rendering on firefox

### DIFF
--- a/components/contributors/InfoCard.jsx
+++ b/components/contributors/InfoCard.jsx
@@ -27,7 +27,7 @@ export default function InfoCard({
           >
             <img
               className=" h-28 w-28 md:h-32 md:w-32 rounded-full border-2 border-indigo-500"
-              src={`https://github.com/${contributor.github}.png`}
+              src={`https://avatars.githubusercontent.com/${contributor.github}`}
               alt={contributor.github}
             />
           </div>

--- a/components/contributors/LeaderboardCard.jsx
+++ b/components/contributors/LeaderboardCard.jsx
@@ -43,7 +43,7 @@ export default function LeaderBoardCard({ contributor, position }) {
               <div className="flex-shrink-0">
                 <img
                   className="h-12 w-12 rounded-full"
-                  src={`https://github.com/${contributor.github}.png`}
+                  src={`https://avatars.githubusercontent.com/${contributor.github}`}
                   alt={contributor.github}
                 />
               </div>

--- a/components/contributors/TopContributor.jsx
+++ b/components/contributors/TopContributor.jsx
@@ -10,7 +10,7 @@ export default function InfoCard({ contributor, minimal = false, category }) {
         <div className="mx-auto mt-2 flex items-center gap-2">
           <img
             className="h-12 w-12 rounded-full"
-            src={`https://github.com/${contributor.github}.png`}
+            src={`https://avatars.githubusercontent.com/${contributor.github}`}
             alt={contributor.github}
           />
           <div className={minimal ? "text-center" : "space-y-2"}>

--- a/pages/contributors/[slug].js
+++ b/pages/contributors/[slug].js
@@ -203,7 +203,7 @@ export default function Contributor({ contributor, slug }) {
                       ></img>
                       <img
                         className="absolute top-1.5 mx-auto h-7 md:h-8 w-7 md:w-8 rounded-full border border-primary-200"
-                        src={`https://github.com/${contributor.github}.png`}
+                        src={`https://avatars.githubusercontent.com/${contributor.github}?size=200`}
                         alt={contributor.github}
                       />
                     </div>
@@ -353,7 +353,7 @@ export async function getStaticProps({ params }) {
   const metaTags = [
     {
       name: "og:image",
-      content: `https://github.com/${params.slug}.png`,
+      content: `https://avatars.githubusercontent.com/${params.slug}`,
     },
     {
       name: "og:title",


### PR DESCRIPTION
avatars.githubusercontent.com has the appropriate CORS headers, so it should not fail on browsers with stricter CORS requirements