### PR TITLE
Show Badge label in dark mode

### DIFF
--- a/components/contributors/BadgeIcons.tsx
+++ b/components/contributors/BadgeIcons.tsx
@@ -57,7 +57,7 @@ export default function BadgeIcons({ skill }: { skill: any }) {
         />
         {skill.currentLevel && (
           <div className="bg-white flex items-center justify-center absolute rounded bottom-0 right-0 z-10 py-0.5 px-1 leading-tight">
-            <span className="text-xs font-medium">
+            <span className="text-xs font-medium text-black">
               {skill.currentLevel.label}
             </span>
           </div>


### PR DESCRIPTION
Fixes #128 
The badge label is visible in dark mode as well
![image](https://github.com/coronasafe/leaderboard/assets/70687348/3e6bb4aa-ebce-4d22-adc1-c93a8b7c5496)
