### PR TITLE
fixes opengraph image not shown for PR close events

### DIFF
--- a/components/gh_events/GitHubEvent.tsx
+++ b/components/gh_events/GitHubEvent.tsx
@@ -55,9 +55,9 @@ export default function GitHubEvent({ event }: { event?: IGitHubEvent }) {
           </a>
         </>
       );
-      body = event.payload.action === "opened" && (
-        <OpenGraphImage url={event.payload.pull_request.html_url} />
-      );
+      body = ["opened", "closed", "reopened"].includes(
+        event.payload.action,
+      ) && <OpenGraphImage url={event.payload.pull_request.html_url} />;
       break;
 
     case "PushEvent":


### PR DESCRIPTION
- fixes #157

<img width="899" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/dfd7a681-4083-46cc-9e41-f61fd330fba2">
