### PR TITLE
Pre-render contributor profile pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 # Ignore data
-data
-contributors
-data-repo
+./data
+./contributors
+./data-repo

--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -19,13 +19,15 @@ import { Contributor } from "@/lib/types";
 import { formatDuration } from "@/lib/utils";
 
 export async function generateStaticParams() {
-  return getContributorsSlugs().map((slug) => {
-    return { slug: slug.file.replace('.md', '') }
-  });
+  return getContributorsSlugs()
+    .filter((slug) => !slug.file.includes("[bot]"))
+    .map((slug) => {
+      return { slug: slug.file.replace(".md", "") };
+    });
 }
 
 type Params = {
-  params: { slug: string; };
+  params: { slug: string };
 };
 
 export default async function Contributor({ params }: Params) {

--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -21,9 +21,7 @@ import { formatDuration } from "@/lib/utils";
 export async function generateStaticParams() {
   return getContributorsSlugs()
     .filter((slug) => !slug.file.includes("[bot]"))
-    .map((slug) => {
-      return { slug: slug.file.replace(".md", "") };
-    });
+    .map((slug) => ({ slug: slug.file.replace(".md", "") }));
 }
 
 type Params = {

--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -5,7 +5,7 @@ import {
   professionalTeamSkills,
   resolveGraduateAttributes,
 } from "../../../config/GraduateAttributes";
-import { getContributorBySlug } from "../../../lib/api";
+import { getContributorBySlug, getContributorsSlugs } from "../../../lib/api";
 import ActivityCalendarGit from "../../../components/contributors/ActivityCalendarGitHub";
 import BadgeIcons from "../../../components/contributors/BadgeIcons";
 import GithubActivity from "../../../components/contributors/GithubActivity";
@@ -18,13 +18,18 @@ import Tooltip from "../../../components/filters/Tooltip";
 import { Contributor } from "@/lib/types";
 import { formatDuration } from "@/lib/utils";
 
+export async function generateStaticParams() {
+  return getContributorsSlugs().map((slug) => {
+    return { slug: slug.file.replace('.md', '') }
+  });
+}
+
 type Params = {
-  params: {
-    slug: string;
-  };
+  params: { slug: string; };
 };
 
-export default async function Contributor({ params: { slug } }: Params) {
+export default async function Contributor({ params }: Params) {
+  const { slug } = params;
   const contributor = getContributorBySlug(slug, true) as Contributor;
   const content = await markdownToHtml(contributor.content || "");
   return (


### PR DESCRIPTION
- Fixes #181

## Deployment Summary before

<img width="1317" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/e8936cfc-1a85-4da1-a5cf-0a3a96086ba9">

## Deployment Summary After

<img width="1197" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/e4f4e9cd-0f62-4386-845b-45d7269d6b48">

