### PR TITLE
Fixes hydration warnings and issue with pre-rendering activity calendar

### DIFF
--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -177,9 +177,7 @@ export default async function Contributor({ params }: Params) {
 
         <div className="px-4 md:p-0">
           <h3 className="font-bold text-foreground my-4">Learning Activity</h3>
-          <Suspense fallback={<div>Loading</div>}>
-            <ActivityCalendarGit calendarData={contributor.calendarData} />
-          </Suspense>
+          <ActivityCalendarGit calendarData={contributor.calendarData} />
         </div>
         <div className="px-4 md:p-0">
           <h3 className="font-bold text-foreground mt-6">Highlights</h3>

--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -266,21 +266,21 @@ export default async function Contributor({ params }: Params) {
               <div className="mt-4">
                 {contributor["activityData"]["open_prs"].map((pr, index) => (
                   <a href={pr.link} key={index} className="flex gap-2">
-                    <p
-                      className={clsx(
-                        "text-sm mb-2 transition-colors duration-75 ease-in-out flex gap-2",
-                        pr?.stale_for >= 7
-                          ? "dark:text-gray-600 text-gray-700 dark:hover:text-primary-200 hover:text-primary-400"
-                          : "dark:text-gray-300 text-gray-400 dark:hover:text-primary-300 hover:text-primary-500",
-                      )}
-                      key={index}
+                    <Tooltip
+                      tip={
+                        ((pr?.stale_for >= 7) as Boolean) &&
+                        `Stale for ${pr?.stale_for} days`
+                      }
+                      tipStyle="absolute w-48 -top-8 translate-x-1/2 text-white text-sm flex flex-row gap-4"
                     >
-                      <Tooltip
-                        tip={
-                          ((pr?.stale_for >= 7) as Boolean) &&
-                          `Stale for ${pr?.stale_for} days`
-                        }
-                        tipStyle="absolute w-48 -top-8 translate-x-1/2 text-white text-sm flex flex-row gap-4"
+                      <p
+                        className={clsx(
+                          "text-sm mb-2 transition-colors duration-75 ease-in-out flex gap-2",
+                          pr?.stale_for >= 7
+                            ? "dark:text-gray-600 text-gray-700 dark:hover:text-primary-200 hover:text-primary-400"
+                            : "dark:text-gray-300 text-gray-400 dark:hover:text-primary-300 hover:text-primary-500",
+                        )}
+                        key={index}
                       >
                         <span className="flex items-center">
                           <span className="text-primary-500 text-sm pr-2">
@@ -302,8 +302,8 @@ export default async function Contributor({ params }: Params) {
                           </code>
                           {pr.title}
                         </span>
-                      </Tooltip>
-                    </p>
+                      </p>
+                    </Tooltip>
                   </a>
                 ))}
               </div>

--- a/components/contributors/ActivityCalendarGitHub.tsx
+++ b/components/contributors/ActivityCalendarGitHub.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ActivityCalendar from "react-activity-calendar";
 import ActivityModal from "./ActivityModal";
 import { useTheme } from "next-themes";
@@ -10,6 +10,17 @@ export default function ActivityCalendarGit({
 }: {
   calendarData: any;
 }) {
+  // Force rendering the calendar only on browser as the component throws the
+  // following when attempted to render on server side.
+  //
+  // calcTextDimensions() requires browser APIs
+  const [isBrowser, setIsBrowser] = useState(false);
+  useEffect(() => {
+    setIsBrowser(
+      !(typeof document === "undefined" || typeof window === "undefined"),
+    );
+  }, []);
+
   const { theme } = useTheme();
 
   const getCalendarData = (year: number) => {
@@ -65,51 +76,52 @@ export default function ActivityCalendarGit({
 
   return (
     <div className="sm:flex gap-3">
-      <div
-        className="py-8 dark:bg-gray-800 bg-gray-100 text-foreground text-center rounded-lg px-6 sm:px-10 xl:text-left hover:cursor-pointer"
-        suppressHydrationWarning
-      >
-        {year === 0 ? (
-          <ActivityCalendar
-            colorScheme={theme === "dark" ? "dark" : "light"}
-            showWeekdayLabels
-            data={calendarData}
-            theme={{
-              light: ["#e5e7eb", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
-              dark: ["#374151", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
-            }}
-            eventHandlers={{
-              onClick: (event) => (data) => {
-                setIsOpen(true);
-                setActivityData(data);
-              },
-            }}
-            labels={{ totalCount: "{{count}} contributions in the last year" }}
-          />
-        ) : (
-          <ActivityCalendar
-            colorScheme={theme === "dark" ? "dark" : "light"}
-            showWeekdayLabels
-            data={getCalendarData(year)}
-            theme={{
-              light: ["#e5e7eb", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
-              dark: ["#374151", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
-            }}
-            eventHandlers={{
-              onClick: (event) => (data) => {
-                setIsOpen(true);
-                setActivityData(data);
-              },
-            }}
-          />
-        )}
+      {isBrowser && (
+        <div className="py-8 dark:bg-gray-800 bg-gray-100 text-foreground text-center rounded-lg px-6 sm:px-10 xl:text-left hover:cursor-pointer">
+          {year === 0 ? (
+            <ActivityCalendar
+              colorScheme={theme === "dark" ? "dark" : "light"}
+              showWeekdayLabels
+              data={calendarData}
+              theme={{
+                light: ["#e5e7eb", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
+                dark: ["#374151", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
+              }}
+              eventHandlers={{
+                onClick: (event) => (data) => {
+                  setIsOpen(true);
+                  setActivityData(data);
+                },
+              }}
+              labels={{
+                totalCount: "{{count}} contributions in the last year",
+              }}
+            />
+          ) : (
+            <ActivityCalendar
+              colorScheme={theme === "dark" ? "dark" : "light"}
+              showWeekdayLabels
+              data={getCalendarData(year)}
+              theme={{
+                light: ["#e5e7eb", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
+                dark: ["#374151", "#d3bff3", "#b08ee6", "#976ae2", "#6025c0"],
+              }}
+              eventHandlers={{
+                onClick: (event) => (data) => {
+                  setIsOpen(true);
+                  setActivityData(data);
+                },
+              }}
+            />
+          )}
 
-        <ActivityModal
-          isopen={isOpen}
-          activityData={activityData}
-          closeFunc={() => setIsOpen(false)}
-        />
-      </div>
+          <ActivityModal
+            isopen={isOpen}
+            activityData={activityData}
+            closeFunc={() => setIsOpen(false)}
+          />
+        </div>
+      )}
       <div className="flex sm:flex-col gap-2 mt-2 sm:mt-0">
         {yearsList.map((y, i) => {
           return (


### PR DESCRIPTION
The third-party activity calendar package causes builds to fail during the pre-rendering of contributors' pages. This was due to the following code in the third-party package.

<img width="587" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/cdf36e99-a310-4e99-b93e-1b59715921a6">


### Changes
- Force the activity calendar to render only in the browser.
- Fixes hydration warning with tooltip in currently working on (had `<div>` inside `<p>`)