### PR TITLE
fix: shortened the contributors list by filtering contributors according to their activity in that particular week.

### DIFF
--- a/app/leaderboard/Leaderboard.tsx
+++ b/app/leaderboard/Leaderboard.tsx
@@ -38,7 +38,6 @@ export default function Leaderboard({
   const [categoryLeaderboard, setCategoryLeaderboard] = useState<Category[]>(
     [],
   );
-
   useEffect(() => {
     let filteredContributors = contributorsList;
 
@@ -59,11 +58,13 @@ export default function Leaderboard({
       );
     }
 
-    filteredContributors = filteredContributors.sort((a: any, b: any) =>
+    filteredContributors = filteredContributors
+    .filter(contributor => contributor.weekSummary.pr_merged>0 || contributor.weekSummary.pr_opened>0 || contributor.weekSummary.pr_reviewed>0 || contributor.weekSummary.issue_opened>0 ) // Filter out contributors with zero contribution
+    .sort((a: any, b: any) =>
       a.weekSummary[sortBy] !== b.weekSummary[sortBy]
         ? a.weekSummary[sortBy] - b.weekSummary[sortBy]
         : a.weekSummary.points - b.weekSummary.points,
-    );
+    );;
 
     if (sortDescending) {
       filteredContributors = filteredContributors.reverse();

--- a/contributors
+++ b/contributors
@@ -1,1 +1,0 @@
-data-repo/contributors

--- a/contributors
+++ b/contributors
@@ -1,0 +1,1 @@
+data-repo/contributors

--- a/data
+++ b/data
@@ -1,1 +1,0 @@
-data-repo/data

--- a/data
+++ b/data
@@ -1,0 +1,1 @@
+data-repo/data


### PR DESCRIPTION
fixes #171 
Truncate the list of contributors on the basis of their activity(raised, merged, reviewed PRs and opend issues) in that particular week.





** This pr seems to have some changes in extra files but it is actually due to replacing the data & contributors files after deleting the force pasted folders. The reason for this is in the discussion of issue #171 . Still if some changes are required please let me know.