### PR TITLE
Fix: Add text-overflow

### DIFF
--- a/components/contributors/InfoCard.tsx
+++ b/components/contributors/InfoCard.tsx
@@ -40,9 +40,7 @@ export default function InfoCard({
         </Link>
         <div
           className={`overflow-hidden ${
-            minimal
-              ? ""
-              : "flex flex-col items-center space-y-2 overflow-hidden"
+            minimal ? "" : "flex flex-col items-center space-y-2"
           }
           `}
         >

--- a/components/contributors/InfoCard.tsx
+++ b/components/contributors/InfoCard.tsx
@@ -38,15 +38,22 @@ export default function InfoCard({
             />
           </div>
         </Link>
-        <div className={minimal ? "" : "flex flex-col items-center space-y-2"}>
-          <div className="font-medium text-lg space-y-1">
+        <div
+          className={`overflow-hidden ${
+            minimal
+              ? ""
+              : "flex flex-col items-center space-y-2 overflow-hidden"
+          }
+          `}
+        >
+          <div className="fnt-medium text-lg space-y-1 overflow-hidden">
             <Link
               href={isClickable ? `/contributors/${contributor.github}` : `#`}
               className=""
             >
               <h3
                 className={clsx(
-                  "text-lg md:text-2xl leading-tight ",
+                  "text-lg md:text-2xl leading-tight overflow-hidden overflow-ellipsis",
                   isClickable && "cursor-pointer hover:text-primary-200",
                 )}
               >


### PR DESCRIPTION
Closes #203 

Added `text-overflow` 


![Screenshot from 2024-01-19 13-42-12](https://github.com/coronasafe/leaderboard/assets/110557519/43a21d5d-444a-4358-94c9-3e068e9f7fc4)
