### PR TITLE
Adds API route `/leaderboard` and ✨ Optimize leaderboard page size

### DIFF
--- a/app/api/leaderboard/functions.ts
+++ b/app/api/leaderboard/functions.ts
@@ -1,0 +1,83 @@
+import { LeaderboardSortKey } from "@/app/leaderboard/Leaderboard";
+import { getContributors } from "@/lib/api";
+import { Highlights } from "@/lib/types";
+
+export type LeaderboardAPIResponse = {
+  user: {
+    slug: string;
+    name: string;
+    title: string;
+    role: ("core" | "intern" | "operations" | "contributor")[];
+    content: string;
+    social: ContributorSocials;
+    joining_date: string;
+  };
+  highlights: Highlights & { pr_stale: number };
+}[];
+
+type ContributorSocials = {
+  github: string;
+  twitter: string;
+  linkedin: string;
+  slack: string;
+};
+
+type OrderingKey = LeaderboardSortKey | `-${LeaderboardSortKey}`;
+
+export const getLeaderboardData = async (
+  dateRange: readonly [Date, Date],
+  ordering: OrderingKey,
+) => {
+  const sortBy = ordering.replace("-", "") as LeaderboardSortKey;
+  const shouldReverse = !ordering.startsWith("-");
+
+  const contributors = await getContributors();
+
+  const data = contributors
+    .filter((a) => a.highlights.points)
+    .map((contributor) => ({
+      ...contributor,
+      summary: contributor.summarize(...dateRange),
+    }))
+    .filter((contributor) => contributor.summary.points)
+    .sort((a, b) => {
+      if (sortBy === "pr_stale") {
+        return b.activityData.pr_stale - a.activityData.pr_stale;
+      }
+      return b.summary[sortBy] - a.summary[sortBy];
+    });
+
+  if (shouldReverse) {
+    data.reverse();
+  }
+
+  return data.map((contributor): LeaderboardAPIResponse[number] => {
+    const role: LeaderboardAPIResponse[number]["user"]["role"] = [];
+
+    if (contributor.intern) role.push("intern");
+    if (contributor.operations) role.push("operations");
+    if (contributor.core) role.push("core");
+    if (!role.length) role.push("contributor");
+
+    return {
+      user: {
+        slug: contributor.slug,
+        name: contributor.name,
+        title: contributor.title,
+        role: role,
+        content: contributor.content,
+        joining_date: contributor.joining_date,
+        social: {
+          github: contributor.github,
+          linkedin: contributor.linkedin,
+          slack: contributor.slack,
+          twitter: contributor.twitter,
+        },
+      },
+      highlights: {
+        ...contributor.summary,
+        pr_stale: contributor.activityData.pr_stale,
+      },
+    };
+  });
+};

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,87 +1,8 @@
 import { LeaderboardSortKey } from "@/app/leaderboard/Leaderboard";
-import { getContributors } from "@/lib/api";
-import { Highlights } from "@/lib/types";
 import { parseDateRangeSearchParam } from "@/lib/utils";
-
-export type LeaderboardAPIResponse = {
-  user: {
-    slug: string;
-    name: string;
-    title: string;
-    role: ("core" | "intern" | "operations" | "contributor")[];
-    content: string;
-    social: ContributorSocials;
-    joining_date: string;
-  };
-  highlights: Highlights & { pr_stale: number };
-}[];
-
-type ContributorSocials = {
-  github: string;
-  twitter: string;
-  linkedin: string;
-  slack: string;
-};
+import { getLeaderboardData } from "./functions";
 
 type OrderingKey = LeaderboardSortKey | `-${LeaderboardSortKey}`;
-
-export const getLeaderboardData = async (
-  dateRange: readonly [Date, Date],
-  ordering: OrderingKey,
-) => {
-  const sortBy = ordering.replace("-", "") as LeaderboardSortKey;
-  const shouldReverse = !ordering.startsWith("-");
-
-  const contributors = await getContributors();
-
-  const data = contributors
-    .filter((a) => a.highlights.points)
-    .map((contributor) => ({
-      ...contributor,
-      summary: contributor.summarize(...dateRange),
-    }))
-    .filter((contributor) => contributor.summary.points)
-    .sort((a, b) => {
-      if (sortBy === "pr_stale") {
-        return b.activityData.pr_stale - a.activityData.pr_stale;
-      }
-      return b.summary[sortBy] - a.summary[sortBy];
-    });
-
-  if (shouldReverse) {
-    data.reverse();
-  }
-
-  return data.map((contributor): LeaderboardAPIResponse[number] => {
-    const role: LeaderboardAPIResponse[number]["user"]["role"] = [];
-
-    if (contributor.intern) role.push("intern");
-    if (contributor.operations) role.push("operations");
-    if (contributor.core) role.push("core");
-    if (!role.length) role.push("contributor");
-
-    return {
-      user: {
-        slug: contributor.slug,
-        name: contributor.name,
-        title: contributor.title,
-        role: role,
-        content: contributor.content,
-        joining_date: contributor.joining_date,
-        social: {
-          github: contributor.github,
-          linkedin: contributor.linkedin,
-          slack: contributor.slack,
-          twitter: contributor.twitter,
-        },
-      },
-      highlights: {
-        ...contributor.summary,
-        pr_stale: contributor.activityData.pr_stale,
-      },
-    };
-  });
-};
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,93 @@
+import { LeaderboardSortKey } from "@/app/leaderboard/Leaderboard";
+import { getContributors } from "@/lib/api";
+import { Highlights } from "@/lib/types";
+import { parseDateRangeSearchParam } from "@/lib/utils";
+
+export type LeaderboardAPIResponse = {
+  user: {
+    slug: string;
+    name: string;
+    title: string;
+    role: ("core" | "intern" | "operations" | "contributor")[];
+    content: string;
+    social: ContributorSocials;
+    joining_date: string;
+  };
+  highlights: Highlights & { pr_stale: number };
+}[];
+
+type ContributorSocials = {
+  github: string;
+  twitter: string;
+  linkedin: string;
+  slack: string;
+};
+
+type OrderingKey = LeaderboardSortKey | `-${LeaderboardSortKey}`;
+
+export const getLeaderboardData = async (
+  dateRange: readonly [Date, Date],
+  ordering: OrderingKey,
+) => {
+  const sortBy = ordering.replace("-", "") as LeaderboardSortKey;
+  const shouldReverse = !ordering.startsWith("-");
+
+  const contributors = await getContributors();
+
+  const data = contributors
+    .filter((a) => a.highlights.points)
+    .map((contributor) => ({
+      ...contributor,
+      summary: contributor.summarize(...dateRange),
+    }))
+    .filter((contributor) => contributor.summary.points)
+    .sort((a, b) => {
+      if (sortBy === "pr_stale") {
+        return b.activityData.pr_stale - a.activityData.pr_stale;
+      }
+      return b.summary[sortBy] - a.summary[sortBy];
+    });
+
+  if (shouldReverse) {
+    data.reverse();
+  }
+
+  return data.map((contributor): LeaderboardAPIResponse[number] => {
+    const role: LeaderboardAPIResponse[number]["user"]["role"] = [];
+
+    if (contributor.intern) role.push("intern");
+    if (contributor.operations) role.push("operations");
+    if (contributor.core) role.push("core");
+    if (!role.length) role.push("contributor");
+
+    return {
+      user: {
+        slug: contributor.slug,
+        name: contributor.name,
+        title: contributor.title,
+        role: role,
+        content: contributor.content,
+        joining_date: contributor.joining_date,
+        social: {
+          github: contributor.github,
+          linkedin: contributor.linkedin,
+          slack: contributor.slack,
+          twitter: contributor.twitter,
+        },
+      },
+      highlights: {
+        ...contributor.summary,
+        pr_stale: contributor.activityData.pr_stale,
+      },
+    };
+  });
+};
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  const dateRange = parseDateRangeSearchParam(searchParams.get("between"));
+  const ordering = searchParams.get("sort") ?? "-points";
+
+  return Response.json(getLeaderboardData(dateRange, ordering as OrderingKey));
+}

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -89,5 +89,7 @@ export async function GET(request: Request) {
   const dateRange = parseDateRangeSearchParam(searchParams.get("between"));
   const ordering = searchParams.get("sort") ?? "-points";
 
-  return Response.json(getLeaderboardData(dateRange, ordering as OrderingKey));
+  const data = await getLeaderboardData(dateRange, ordering as OrderingKey);
+
+  return Response.json(data);
 }

--- a/app/leaderboard/Leaderboard.tsx
+++ b/app/leaderboard/Leaderboard.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import LeaderBoardCard from "@/components/contributors/LeaderboardCard";
-import { Contributor } from "@/lib/types";
+import LeaderboardCard from "@/components/contributors/LeaderboardCard";
 import { TbZoomQuestion } from "react-icons/tb";
-import { LeaderboardResultSet } from "./page";
 import TopContributor from "../../components/contributors/TopContributor";
 import { useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -12,19 +10,16 @@ import DateRangePicker, { formatDate } from "@/components/DateRangePicker";
 import Search from "@/components/filters/Search";
 import Sort from "@/components/filters/Sort";
 import format from "date-fns/format";
+import { LeaderboardAPIResponse } from "../api/leaderboard/route";
 
-type Props = {
-  resultSet: LeaderboardResultSet;
-};
-
-export default function Leaderboard(props: Props) {
+export default function Leaderboard(props: { data: LeaderboardAPIResponse }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState("");
   const [start, end] = parseDateRangeSearchParam(searchParams.get("between"));
 
-  let data = props.resultSet;
+  let data = props.data;
 
   if (searchTerm) {
     data = data.filter(filterBySearchTerm(searchTerm.toLowerCase()));
@@ -105,8 +100,8 @@ export default function Leaderboard(props: Props) {
                     <ul className="space-y-6 lg:space-y-8 overflow-x-auto p-6">
                       {data.map((contributor, index) => {
                         return (
-                          <li key={contributor.github}>
-                            <LeaderBoardCard
+                          <li key={contributor.user.social.github}>
+                            <LeaderboardCard
                               position={index}
                               contributor={contributor}
                             />
@@ -161,11 +156,11 @@ export default function Leaderboard(props: Props) {
 }
 
 const filterBySearchTerm = (searchTermLC: string) => {
-  return (contributor: Contributor) =>
-    contributor.name.toLowerCase().includes(searchTermLC) ||
-    contributor.github.toLowerCase().includes(searchTermLC) ||
-    contributor.linkedin.toLowerCase().includes(searchTermLC) ||
-    contributor.twitter.toLowerCase().includes(searchTermLC);
+  return (item: LeaderboardAPIResponse[number]) =>
+    item.user.name.toLowerCase().includes(searchTermLC) ||
+    item.user.social.github.toLowerCase().includes(searchTermLC) ||
+    item.user.social.linkedin.toLowerCase().includes(searchTermLC) ||
+    item.user.social.twitter.toLowerCase().includes(searchTermLC);
 };
 
 const SORT_BY_OPTIONS = {

--- a/app/leaderboard/Leaderboard.tsx
+++ b/app/leaderboard/Leaderboard.tsx
@@ -10,7 +10,7 @@ import DateRangePicker, { formatDate } from "@/components/DateRangePicker";
 import Search from "@/components/filters/Search";
 import Sort from "@/components/filters/Sort";
 import format from "date-fns/format";
-import { LeaderboardAPIResponse } from "../api/leaderboard/route";
+import { LeaderboardAPIResponse } from "../api/leaderboard/functions";
 
 export default function Leaderboard(props: { data: LeaderboardAPIResponse }) {
   const router = useRouter();

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,6 +1,6 @@
+import { getLeaderboardData } from "../api/leaderboard/functions";
 import Leaderboard, { LeaderboardSortKey } from "./Leaderboard";
 import { parseDateRangeSearchParam } from "@/lib/utils";
-import { getLeaderboardData } from "../api/leaderboard/route";
 
 type PageProps = {
   searchParams: {

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,69 +1,20 @@
-import { getContributors } from "@/lib/api";
-import { Contributor } from "@/lib/types";
 import Leaderboard, { LeaderboardSortKey } from "./Leaderboard";
 import { parseDateRangeSearchParam } from "@/lib/utils";
-
-const getResultSet = async (searchParams: PageProps["searchParams"]) => {
-  const [start, end] = parseDateRangeSearchParam(searchParams.between);
-  const sortBy = searchParams.sortBy ?? "points";
-
-  let data = (await getContributors()).filter((a) => a.highlights.points);
-
-  const filterByRole = (contributor: Contributor) => {
-    const roles = searchParams.roles?.split(",") ?? [];
-    if (
-      roles.includes("contributor") &&
-      !contributor.intern &&
-      !contributor.operations &&
-      !contributor.core
-    )
-      return true;
-    for (const role of roles) {
-      if (contributor[role as "intern" | "operations" | "core"]) return true;
-    }
-    return false;
-  };
-
-  if (searchParams.roles) {
-    data = data.filter(filterByRole);
-  }
-
-  const result = data
-    .map((contributor) => ({
-      ...contributor,
-      summary: contributor.summarize(start, end),
-      // Because functions are not serializable and cannot be passed as
-      // prop to client components from a server component
-      summarize: undefined,
-    }))
-    .filter((contributor) => contributor.summary.points)
-    .sort((a, b) => {
-      if (sortBy === "pr_stale") {
-        return b.activityData.pr_stale - a.activityData.pr_stale;
-      }
-      return b.summary[sortBy] - a.summary[sortBy];
-    });
-
-  if (searchParams.ordering === "asc") {
-    result.reverse();
-  }
-
-  return result;
-};
-
-export type LeaderboardResultSet = Awaited<ReturnType<typeof getResultSet>>;
+import { getLeaderboardData } from "../api/leaderboard/route";
 
 type PageProps = {
   searchParams: {
     between?: string; // <start-date>...<end-date>
-    sortBy?: LeaderboardSortKey;
-    ordering?: "desc" | "asc";
+    sortBy?: LeaderboardSortKey | `-${LeaderboardSortKey}`;
     roles?: string; // typeof subsetOf("core", "intern", "operations", "contributor").join(',')
   };
 };
 
 export default async function LeaderboardPage({ searchParams }: PageProps) {
-  const resultSet = await getResultSet(searchParams);
+  const data = await getLeaderboardData(
+    parseDateRangeSearchParam(searchParams.between),
+    searchParams.sortBy ?? "-points",
+  );
 
-  return <Leaderboard resultSet={resultSet} />;
+  return <Leaderboard data={data} />;
 }

--- a/components/contributors/LeaderboardCard.tsx
+++ b/components/contributors/LeaderboardCard.tsx
@@ -1,14 +1,13 @@
-import { LeaderboardResultSet } from "@/app/leaderboard/page";
-import { Contributor } from "@/lib/types";
+import { LeaderboardAPIResponse } from "@/app/api/leaderboard/route";
 import Link from "next/link";
 import { FiAlertTriangle } from "react-icons/fi";
 
 /* eslint-disable @next/next/no-img-element */
-export default function LeaderBoardCard({
+export default function LeaderboardCard({
   contributor,
   position,
 }: {
-  contributor: LeaderboardResultSet[number];
+  contributor: LeaderboardAPIResponse[number];
   position: number;
 }) {
   const userPosition = position + 1;
@@ -33,7 +32,10 @@ export default function LeaderBoardCard({
   }
 
   return (
-    <Link href={"/contributors/" + contributor.github} className="block">
+    <Link
+      href={"/contributors/" + contributor.user.social.github}
+      className="block"
+    >
       <div className="flex border-2 border-transparent hover:border-primary-400 hover:shadow-lg hover:scale-105 transition-all duration-300 ease-in-out transform rounded-lg p-4 md:items-center px-2 sm:px-6 md:py-0 py-2 cursor-pointer">
         {!hideBadges && (
           <div
@@ -56,16 +58,16 @@ export default function LeaderBoardCard({
                   className={`h-14 w-14 rounded-full ${
                     position < 3 && "animate-circular-shadow"
                   }`}
-                  src={`https://avatars.githubusercontent.com/${contributor.github}`}
-                  alt={contributor.github}
+                  src={`https://avatars.githubusercontent.com/${contributor.user.social.github}`}
+                  alt={contributor.user.social.github}
                 />
               </div>
               <div className="ml-4">
                 <div className="font-bold text-green-500 truncate">
-                  {contributor.name}
+                  {contributor.user.name}
                 </div>
                 <p className="flex items-center text-sm text-foreground">
-                  <span className="truncate">{contributor.title}</span>
+                  <span className="truncate">{contributor.user.title}</span>
                 </p>
               </div>
             </div>
@@ -91,21 +93,21 @@ export default function LeaderBoardCard({
                       />
                     </svg>
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">
-                      {contributor.summary.pr_opened}
+                      {contributor.highlights.pr_opened}
                     </span>
 
                     <span className="ml-2 text-sm leading-5 text-foreground">
                       opened
                     </span>
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">
-                      {contributor.summary.pr_reviewed}
+                      {contributor.highlights.pr_reviewed}
                     </span>
 
                     <span className="ml-2 text-sm leading-5 text-foreground">
                       reviewed
                     </span>
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">
-                      {contributor.summary.pr_merged}
+                      {contributor.highlights.pr_merged}
                     </span>
 
                     <span className="ml-2 text-sm leading-5 text-foreground">
@@ -113,12 +115,12 @@ export default function LeaderBoardCard({
                     </span>
                   </div>
                 </dd>
-                {contributor.activityData.pr_stale ? (
+                {contributor.highlights.pr_stale ? (
                   <dd className="flex mt-2">
                     <div className="flex items-center">
                       <span className="flex text-sm leading-5 text-yellow-500 dark:text-yellow-200">
                         <FiAlertTriangle size={18} className="mr-2" />{" "}
-                        {contributor.activityData.pr_stale} stale
+                        {contributor.highlights.pr_stale} stale
                       </span>
                     </div>
                   </dd>
@@ -142,14 +144,14 @@ export default function LeaderBoardCard({
                       />
                     </svg>
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">
-                      {contributor.summary.eod_update}
+                      {contributor.highlights.eod_update}
                     </span>
 
                     <span className="ml-2 text-sm leading-5 text-foreground">
                       EOD updates
                     </span>
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">
-                      {contributor.summary.comment_created}
+                      {contributor.highlights.comment_created}
                     </span>
 
                     <span className="ml-2 text-sm leading-5 font-semibold text-gray-500 dark:text-gray-100">

--- a/components/contributors/LeaderboardCard.tsx
+++ b/components/contributors/LeaderboardCard.tsx
@@ -1,4 +1,4 @@
-import { LeaderboardAPIResponse } from "@/app/api/leaderboard/route";
+import { LeaderboardAPIResponse } from "@/app/api/leaderboard/functions";
 import Link from "next/link";
 import { FiAlertTriangle } from "react-icons/fi";
 

--- a/components/contributors/TopContributor.tsx
+++ b/components/contributors/TopContributor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { LeaderboardResultSet } from "@/app/leaderboard/page";
+import { LeaderboardAPIResponse } from "@/app/api/leaderboard/route";
 import Link from "next/link";
 
 export const TOP_CONTRIBUTOR_CATEGORIES = {
@@ -17,16 +17,16 @@ export default function InfoCard({
   data,
   category,
 }: {
-  data: LeaderboardResultSet;
+  data: LeaderboardAPIResponse;
   category: TopContributorCategoryKey;
 }) {
-  let resultSet = data.filter((c) => c.summary[category]);
+  let resultSet = data.filter((c) => c.highlights[category]);
 
-  const points = Math.max(...resultSet.map((c) => c.summary[category]));
+  const points = Math.max(...resultSet.map((c) => c.highlights[category]));
 
   resultSet = resultSet
-    .filter((c) => c.summary[category] === points)
-    .sort((a, b) => b.summary.points - a.summary.points)
+    .filter((c) => c.highlights[category] === points)
+    .sort((a, b) => b.highlights.points - a.highlights.points)
     .slice(0, 3);
 
   if (!resultSet.length) return null;
@@ -48,20 +48,20 @@ export default function InfoCard({
             className={`relative hover:scale-105 ${
               ["opacity-100", "opacity-80", "opacity-60"][0]
             } hover:opacity-100`}
-            key={contributor.github}
+            key={contributor.user.social.github}
           >
             <Link
-              href={`/contributors/${contributor.github}`}
+              href={`/contributors/${contributor.user.social.github}`}
               className="flex gap-4 items-center w-full"
             >
               <img
                 className="rounded-full h-11 w-11 ring-1 ring-primary-500 shadow-md shadow-primary-500"
-                src={`https://avatars.githubusercontent.com/${contributor.github}`}
-                alt={contributor.github}
-                title={contributor.name}
+                src={`https://avatars.githubusercontent.com/${contributor.user.social.github}`}
+                alt={contributor.user.social.github}
+                title={contributor.user.name}
               />
               <span className="font-bold text-primary-400">
-                {contributor.name}
+                {contributor.user.name}
               </span>
             </Link>
           </li>

--- a/components/contributors/TopContributor.tsx
+++ b/components/contributors/TopContributor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { LeaderboardAPIResponse } from "@/app/api/leaderboard/route";
+import { LeaderboardAPIResponse } from "@/app/api/leaderboard/functions";
 import Link from "next/link";
 
 export const TOP_CONTRIBUTOR_CATEGORIES = {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -59,7 +59,7 @@ export const parseDateRangeSearchParam = (
     const start = new Date(startStr);
     const end = new Date(endStr);
     end.setHours(23, 59, 59);
-    return [start, end];
+    return [start, end] as const;
   }
 
   // Last 7 days
@@ -67,7 +67,7 @@ export const parseDateRangeSearchParam = (
   const start = new Date(end);
   start.setDate(end.getDate() - relativeDaysBefore);
   end.setHours(23, 59, 59);
-  return [start, end];
+  return [start, end] as const;
 };
 
 export const padZero = (num: number) => (num < 10 ? `0${num}` : num);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",
-    "@types/node": "^20.3.1",
+    "@types/node": "^20.11.17",
     "@types/react": "^18.2.14",
     "autoprefixer": "^10.4.14",
     "eslint": "8.16.0",
@@ -41,6 +41,6 @@
     "postcss": "^8.4.31",
     "prettier": "^3.1.1",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.1.3"
+    "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ devDependencies:
     specifier: ^0.5.9
     version: 0.5.9(tailwindcss@3.3.2)
   '@types/node':
-    specifier: ^20.3.1
-    version: 20.3.1
+    specifier: ^20.11.17
+    version: 20.11.17
   '@types/react':
     specifier: ^18.2.14
     version: 18.2.14
@@ -72,7 +72,7 @@ devDependencies:
     version: 8.16.0
   eslint-config-next:
     specifier: ^14.0.4
-    version: 14.0.4(eslint@8.16.0)(typescript@5.1.3)
+    version: 14.0.4(eslint@8.16.0)(typescript@5.3.3)
   eslint-config-prettier:
     specifier: ^9.1.0
     version: 9.1.0(eslint@8.16.0)
@@ -92,8 +92,8 @@ devDependencies:
     specifier: ^3.3.2
     version: 3.3.2
   typescript:
-    specifier: ^5.1.3
-    version: 5.1.3
+    specifier: ^5.3.3
+    version: 5.3.3
 
 packages:
 
@@ -370,8 +370,10 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: false
 
-  /@types/node@20.3.1:
-    resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
+  /@types/node@20.11.17:
+    resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/parse5@6.0.3:
@@ -398,7 +400,7 @@ packages:
     resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
     dev: false
 
-  /@typescript-eslint/parser@6.14.0(eslint@8.16.0)(typescript@5.1.3):
+  /@typescript-eslint/parser@6.14.0(eslint@8.16.0)(typescript@5.3.3):
     resolution: {integrity: sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -410,11 +412,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.14.0
       '@typescript-eslint/types': 6.14.0
-      '@typescript-eslint/typescript-estree': 6.14.0(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 6.14.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.14.0
       debug: 4.3.4
       eslint: 8.16.0
-      typescript: 5.1.3
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -432,7 +434,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.14.0(typescript@5.1.3):
+  /@typescript-eslint/typescript-estree@6.14.0(typescript@5.3.3):
     resolution: {integrity: sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -447,8 +449,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.1.3)
-      typescript: 5.1.3
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1073,7 +1075,7 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /eslint-config-next@14.0.4(eslint@8.16.0)(typescript@5.1.3):
+  /eslint-config-next@14.0.4(eslint@8.16.0)(typescript@5.3.3):
     resolution: {integrity: sha512-9/xbOHEQOmQtqvQ1UsTQZpnA7SlDMBtuKJ//S4JnoyK3oGLhILKXdBgu/UO7lQo/2xOykQULS1qQ6p2+EpHgAQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -1084,7 +1086,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.0.4
       '@rushstack/eslint-patch': 1.6.0
-      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.3.3)
       eslint: 8.16.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.14.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.16.0)
@@ -1092,7 +1094,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.16.0)
       eslint-plugin-react: 7.33.2(eslint@8.16.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.16.0)
-      typescript: 5.1.3
+      typescript: 5.3.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -1161,7 +1163,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.16.0
       eslint-import-resolver-node: 0.3.9
@@ -1180,7 +1182,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.16.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -3554,13 +3556,13 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
-  /ts-api-utils@1.0.3(typescript@5.1.3):
+  /ts-api-utils@1.0.3(typescript@5.3.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.3
+      typescript: 5.3.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -3629,8 +3631,8 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -3642,6 +3644,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unified@10.1.2:


### PR DESCRIPTION
## ✨ Leaderboard Page Optimizations - Reduced page size by 82x times

**Before**

<img width="450" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/c4ae026c-cb7e-4695-abc5-b3f62d547e8b">

**After**
<img width="443" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/ab5eb79f-0e5d-432a-aa70-7e08ae2bbbbc">

## New API Route `GET /api/leaderboard`

- Fixes #215

<img width="2435" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/2e73d68e-8757-4e23-8b59-35e09ae3b460">
