### PR TITLE
Adds support for showing Active Projects

### DIFF
--- a/app/contributors/[slug]/page.tsx
+++ b/app/contributors/[slug]/page.tsx
@@ -172,7 +172,7 @@ export default async function Contributor({ params }: Params) {
           <h3 className="font-bold text-foreground my-4">Short Bio</h3>
           <div className="dark:bg-gray-800 bg-gray-100 w-full rounded-lg ">
             <div className="py-10 px-6 rounded-lg xl:px-10">
-              <Markdown content={contributor.content} />
+              <Markdown>{contributor.content}</Markdown>
             </div>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,9 @@ import InfoCard from "../components/contributors/InfoCard";
 import Link from "next/link";
 import { getContributors } from "../lib/api";
 import GitHubEvents from "@/components/gh_events/GitHubEvents";
-import {
-  MdOutlineArrowForward,
-  MdOutlineArrowForwardIos,
-} from "react-icons/md";
+import { MdOutlineArrowForwardIos } from "react-icons/md";
+import ActiveProjects from "./projects/ActiveProjects";
+import { ACTIVE_PROJECT_LABELS } from "./projects/constants";
 
 export default async function Home() {
   const contributors = (await getContributors()).sort(
@@ -15,19 +14,19 @@ export default async function Home() {
   return (
     <div className="bg-background text-foreground min-h-screen">
       <section className="bg-background border-t dark:border-gray-700 border-gray-300 ">
-        <div className="max-w-6xl mx-auto">
+        <div className="max-w-7xl mx-auto">
           <div className="border-gray-600 mx-4 xl:mx-0">
-            <div className="lg:grid lg:grid-cols-12 lg:gap-12 2xl:gap-5 px-0 pb-10 lg:pb-20">
+            <div className="lg:grid lg:grid-cols-12 lg:gap-12 px-0 pb-10 lg:pb-20">
               <div className="lg:col-span-8 space-y-20">
                 {process.env.NEXT_PUBLIC_ORG_INFO ? (
                   <div className="pt-20">
                     <div className="mx-auto max-w-7xl">
                       <div className="space-y-12">
                         <div className="space-y-5 sm:space-y-4 md:max-w-xl lg:max-w-3xl xl:max-w-none">
-                          <h2 className="text-3xl font-bold tracking-tight sm:text-5xl">
+                          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
                             What we do?
                           </h2>
-                          <p className="text-lg text-gray-400 font-inter text-justify font-medium">
+                          <p className="text-lg text-gray-500 dark:text-gray-400 font-inter text-justify font-medium">
                             {process.env.NEXT_PUBLIC_ORG_INFO}
                           </p>
                         </div>
@@ -38,23 +37,44 @@ export default async function Home() {
                   <div className="pt-0" />
                 )}
 
-                <div>
-                  <div className="mx-auto">
-                    <div className="space-y-12">
-                      <div className="flex justify-between items-center pr-10">
-                        <h2 className="text-3xl font-bold tracking-tight sm:text-5xl">
-                          What&apos;s happening?
-                        </h2>
-                        <Link
-                          href="/feed"
-                          className="text-white px-3 py-2 rounded underline flex items-center gap-1 underline-offset-2 hover:text-primary-200 transition-all duration-200 ease-in-out hover:gap-2"
-                        >
-                          See all events
-                          <MdOutlineArrowForwardIos />
-                        </Link>
-                      </div>
-                      <GitHubEvents minimal />
+                <div className="mx-auto">
+                  <div className="space-y-12">
+                    <div className="flex justify-between items-center pr-5">
+                      <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                        What&apos;s happening?
+                      </h2>
+                      <Link
+                        href="/feed"
+                        className="text-gray-400 px-3 py-2 rounded underline flex items-center gap-1 underline-offset-2 hover:text-primary-200 transition-all duration-200 ease-in-out hover:gap-2"
+                      >
+                        More
+                        <MdOutlineArrowForwardIos />
+                      </Link>
                     </div>
+                    <GitHubEvents minimal />
+                  </div>
+                </div>
+
+                <div className="mx-auto">
+                  <div className="space-y-12">
+                    <div className="flex justify-between items-center pr-5">
+                      <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                        Active Projects
+                      </h2>
+                      <Link
+                        href="/projects"
+                        className="text-gray-400 px-3 py-2 rounded underline flex items-center gap-1 underline-offset-2 hover:text-primary-200 transition-all duration-200 ease-in-out hover:gap-2"
+                      >
+                        More
+                        <MdOutlineArrowForwardIos />
+                      </Link>
+                    </div>
+                    <ActiveProjects
+                      small
+                      className="grid grid-cols-1 lg:grid-cols-2 gap-4 font-inter"
+                      labels={ACTIVE_PROJECT_LABELS}
+                      limit={6}
+                    />
                   </div>
                 </div>
 

--- a/app/projects/ActiveProjects.tsx
+++ b/app/projects/ActiveProjects.tsx
@@ -1,0 +1,204 @@
+import Markdown from "@/components/Markdown";
+import RelativeTime from "@/components/RelativeTime";
+import { parseIssueNumber } from "@/lib/utils";
+import { FiExternalLink, FiGithub } from "react-icons/fi";
+import Link from "next/link";
+import { ActiveProjectLabelConfig } from "./constants";
+
+const accessToken = "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";
+
+type FetchIssuesResponse = {
+  data: {
+    organization: {
+      repositories: {
+        edges: {
+          node: {
+            name: string;
+            issues: {
+              edges: {
+                node: {
+                  title: string;
+                  body: string;
+                  url: string;
+                  createdAt: string;
+                  updatedAt: string;
+                  author: { login: string };
+                  labels: {
+                    edges: {
+                      node: {
+                        name: string;
+                      };
+                    }[];
+                  };
+                };
+              }[];
+            };
+          };
+        }[];
+      };
+    };
+  };
+};
+
+async function fetchIssues(labels: string[]) {
+  const labelsFilter = labels.map((label) => `"${label}"`).join(", ");
+
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+    {
+      organization(login: "${process.env.NEXT_PUBLIC_GITHUB_ORG}") {
+        repositories(first: 100, orderBy: {field: PUSHED_AT, direction: DESC}) {
+          edges {
+            node {
+              name
+              issues(first: 100, states: OPEN, labels: [${labelsFilter}]) {
+                edges {
+                  node {
+                    title
+                    body
+                    url
+                    createdAt
+                    updatedAt
+                    author {
+                      login
+                    },
+                    labels(first: 5) {
+                      edges {
+                        node {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    `,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`HTTP error! status: ${res.status}`);
+  }
+
+  const json = (await res.json()) as FetchIssuesResponse;
+
+  const result = json.data.organization.repositories.edges.flatMap((repo) =>
+    repo.node.issues.edges.map((issue) => ({
+      ...issue.node,
+      labels: issue.node.labels.edges.map((label) => label.node.name),
+      repo: repo.node.name,
+      number: parseIssueNumber(issue.node.url),
+    })),
+  );
+
+  return result;
+}
+
+export default async function ActiveProjects(props: {
+  limit?: number;
+  small?: boolean;
+  className?: string;
+  labels: ActiveProjectLabelConfig;
+}) {
+  const issues = (await fetchIssues(Object.keys(props.labels)))
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getDate() - new Date(a.updatedAt).getDate(),
+    )
+    .slice(0, props.limit);
+
+  return (
+    <ul className={props.className}>
+      {issues.map((issue) => (
+        <li
+          key={issue.url}
+          id={`${issue.repo}-${issue.number}`}
+          className="flex flex-col rounded-lg border shadow-sm dark:border-gray-700"
+        >
+          <div className="flex justify-between items-center p-6 pt-4 pb-0">
+            <div
+              className={`flex items-center ${props.small ? "gap-2" : "gap-3"}`}
+            >
+              <div className="flex flex-wrap gap-2">
+                {issue.labels
+                  .filter((label) => label in props.labels)
+                  .map((label) => (
+                    <a
+                      key={label}
+                      href={props.labels[label].ref}
+                      target="_blank"
+                      className={`rounded-full border font-semibold capitalize ${
+                        props.labels[label].className
+                      } ${
+                        props.small
+                          ? "px-2.5 py-1 text-xs border-gray-200 dark:border-gray-800"
+                          : "px-3 py-1 text-sm border-current"
+                      }`}
+                    >
+                      {props.small ? label : props.labels[label].name}
+                    </a>
+                  ))}
+              </div>
+              <a
+                href={issue.url}
+                target="_blank"
+                className={`font-mono text-gray-700 dark:text-gray-300 font-bold tracking-wide ${
+                  props.small ? "text-xs" : "text-sm"
+                }`}
+              >
+                <span className="text-gray-400 tracking-normal pr-0.5">
+                  {process.env.NEXT_PUBLIC_GITHUB_ORG}/{issue.repo}
+                </span>
+                #{issue.number}
+              </a>
+            </div>
+            {props.small ? (
+              <Link
+                href={`/projects#${issue.repo}-${issue.number}`}
+                className="rounded-lg border text-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-800 px-4 py-2 flex items-center text-sm gap-2 transition-colors hover:bg-gray-100 hover:text-gray-900 hover:dark:bg-gray-800 hover:dark:text-gray-100"
+              >
+                <FiExternalLink />
+                View
+              </Link>
+            ) : (
+              <a
+                href={issue.url}
+                target="_blank"
+                className="rounded-lg border text-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-800 px-4 py-2 flex items-center text-sm gap-2 transition-colors hover:bg-gray-100 hover:text-gray-900 hover:dark:bg-gray-800 hover:dark:text-gray-100"
+              >
+                <FiGithub />
+                Open in GitHub
+              </a>
+            )}
+          </div>
+
+          <div className="flex flex-col space-y-2 p-6">
+            <h3 className={`font-semibold text-2xl`}>{issue.title}</h3>
+            <p className="text-gray-700 dark:text-gray-300 text-sm">
+              Opened by{" "}
+              <span className="font-semibold">{issue.author.login}</span>{" "}
+              <RelativeTime time={issue.createdAt} className="text-gray-500" />
+            </p>
+          </div>
+
+          {!props.small && (
+            <div className="p-6 text-sm break-all bg-gray-100 dark:bg-gray-800 ">
+              <Markdown>{issue.body}</Markdown>
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/projects/ActiveProjects.tsx
+++ b/app/projects/ActiveProjects.tsx
@@ -5,8 +5,6 @@ import { FiExternalLink, FiGithub } from "react-icons/fi";
 import Link from "next/link";
 import { ActiveProjectLabelConfig } from "./constants";
 
-const accessToken = "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";
-
 type FetchIssuesResponse = {
   data: {
     organization: {
@@ -42,6 +40,17 @@ type FetchIssuesResponse = {
 
 async function fetchIssues(labels: string[]) {
   const labelsFilter = labels.map((label) => `"${label}"`).join(", ");
+
+  const accessToken = process.env.GITHUB_PAT;
+
+  if (!accessToken) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("'GITHUB_PAT' is not configured in the environment.");
+      return [];
+    }
+
+    throw "'GITHUB_PAT' is not configured in the environment.";
+  }
 
   const res = await fetch("https://api.github.com/graphql", {
     method: "POST",
@@ -117,6 +126,14 @@ export default async function ActiveProjects(props: {
         new Date(b.updatedAt).getDate() - new Date(a.updatedAt).getDate(),
     )
     .slice(0, props.limit);
+
+  if (issues.length === 0) {
+    return (
+      <span className="flex w-full justify-center text-gray-600 dark:text-gray-400 text-lg font-semibold py-10">
+        No ongoing active projects
+      </span>
+    );
+  }
 
   return (
     <ul className={props.className}>

--- a/app/projects/ActiveProjects.tsx
+++ b/app/projects/ActiveProjects.tsx
@@ -5,7 +5,7 @@ import { FiExternalLink, FiGithub } from "react-icons/fi";
 import Link from "next/link";
 import { ActiveProjectLabelConfig } from "./constants";
 
-type FetchIssuesResponse = {
+type GraphQLOrgActiveProjectsResponse = {
   data: {
     organization: {
       repositories: {
@@ -100,7 +100,7 @@ async function fetchIssues(labels: string[]) {
     throw new Error(`HTTP error! status: ${res.status}`);
   }
 
-  const json = (await res.json()) as FetchIssuesResponse;
+  const json = (await res.json()) as GraphQLOrgActiveProjectsResponse;
 
   const result = json.data.organization.repositories.edges.flatMap((repo) =>
     repo.node.issues.edges.map((issue) => ({

--- a/app/projects/ActiveProjects.tsx
+++ b/app/projects/ActiveProjects.tsx
@@ -201,7 +201,13 @@ export default async function ActiveProjects(props: {
           </div>
 
           <div className="flex flex-col space-y-2 p-6">
-            <h3 className={`font-semibold text-2xl`}>{issue.title}</h3>
+            <h3
+              className={`font-semibold ${
+                props.small ? "text-2xl" : "text-4xl pb-2"
+              }`}
+            >
+              {issue.title}
+            </h3>
             <p className="text-gray-700 dark:text-gray-300 text-sm">
               Opened by{" "}
               <span className="font-semibold">{issue.author.login}</span>{" "}

--- a/app/projects/constants.ts
+++ b/app/projects/constants.ts
@@ -11,9 +11,9 @@ export const ACTIVE_PROJECT_LABELS: ActiveProjectLabelConfig = {
     name: "Google Summer of Code",
     ref: "https://summerofcode.withgoogle.com/",
   },
-  C4GT: {
-    className: "text-blue-500",
-    name: "Code for GovTech",
-    ref: "https://www.codeforgovtech.in/",
-  },
+  // C4GT: {
+  //   className: "text-blue-500",
+  //   name: "Code for GovTech",
+  //   ref: "https://www.codeforgovtech.in/",
+  // },
 };

--- a/app/projects/constants.ts
+++ b/app/projects/constants.ts
@@ -1,0 +1,19 @@
+// TODO: make this configurable
+
+export type ActiveProjectLabelConfig = Record<
+  string,
+  { className: string; name: string; ref: string }
+>;
+
+export const ACTIVE_PROJECT_LABELS: ActiveProjectLabelConfig = {
+  GSoC: {
+    className: "text-yellow-500",
+    name: "Google Summer of Code",
+    ref: "https://summerofcode.withgoogle.com/",
+  },
+  C4GT: {
+    className: "text-blue-500",
+    name: "Code for GovTech",
+    ref: "https://www.codeforgovtech.in/",
+  },
+};

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,14 @@
+import ActiveProjects from "./ActiveProjects";
+import { ACTIVE_PROJECT_LABELS } from "./constants";
+
+export default function Page() {
+  return (
+    <div className="mx-auto max-w-4xl p-10">
+      <h1 className="text-4xl pb-10">Active Projects</h1>
+      <ActiveProjects
+        labels={ACTIVE_PROJECT_LABELS}
+        className="flex flex-col gap-10"
+      />
+    </div>
+  );
+}

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -4,13 +4,13 @@ import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 
-export default async function Markdown(props: { content: string }) {
+export default async function Markdown(props: { children: string }) {
   const result = await unified()
     .use(remarkParse)
     .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeStringify)
-    .process(props.content || "");
+    .process(props.children || "");
 
   return (
     <div

--- a/components/RelativeTime.tsx
+++ b/components/RelativeTime.tsx
@@ -1,5 +1,6 @@
 type Props = {
   time: string | Date | number;
+  className?: string;
 };
 
 export default function RelativeTime(props: Props) {
@@ -8,7 +9,11 @@ export default function RelativeTime(props: Props) {
   const absolute = time.toString();
 
   return (
-    <time dateTime={absolute} title={absolute} className="underline">
+    <time
+      dateTime={absolute}
+      title={absolute}
+      className={props.className ?? "underline"}
+    >
       {relative}
     </time>
   );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -76,3 +76,7 @@ export const scrollTo = (id: string | boolean) => {
   const element = document.querySelector(`#${id}`);
   element?.scrollIntoView({ behavior: "smooth", block: "center" });
 };
+
+export const parseIssueNumber = (url: string) => {
+  return url.replace(/^.*github\.com\/[\w-]+\/[\w-]+\/issues\//, "");
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clsx": "^1.2.1",
     "date-fns": "^2.30.0",
     "gray-matter": "^4.0.3",
-    "next": "^14.0.4",
+    "next": "^14.1.0",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-activity-calendar": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,11 +18,11 @@ dependencies:
     specifier: ^4.0.3
     version: 4.0.3
   next:
-    specifier: ^14.0.4
-    version: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^14.1.0
+    version: 14.1.0(react-dom@18.2.0)(react@18.2.0)
   next-themes:
     specifier: ^0.2.1
-    version: 0.2.1(next@14.0.4)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -194,8 +194,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@next/env@14.0.4:
-    resolution: {integrity: sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==}
+  /@next/env@14.1.0:
+    resolution: {integrity: sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==}
     dev: false
 
   /@next/eslint-plugin-next@14.0.4:
@@ -204,8 +204,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-darwin-arm64@14.0.4:
-    resolution: {integrity: sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==}
+  /@next/swc-darwin-arm64@14.1.0:
+    resolution: {integrity: sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -213,8 +213,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@14.0.4:
-    resolution: {integrity: sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==}
+  /@next/swc-darwin-x64@14.1.0:
+    resolution: {integrity: sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -222,8 +222,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@14.0.4:
-    resolution: {integrity: sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==}
+  /@next/swc-linux-arm64-gnu@14.1.0:
+    resolution: {integrity: sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -231,8 +231,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@14.0.4:
-    resolution: {integrity: sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==}
+  /@next/swc-linux-arm64-musl@14.1.0:
+    resolution: {integrity: sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -240,8 +240,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@14.0.4:
-    resolution: {integrity: sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==}
+  /@next/swc-linux-x64-gnu@14.1.0:
+    resolution: {integrity: sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -249,8 +249,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@14.0.4:
-    resolution: {integrity: sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==}
+  /@next/swc-linux-x64-musl@14.1.0:
+    resolution: {integrity: sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -258,8 +258,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@14.0.4:
-    resolution: {integrity: sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==}
+  /@next/swc-win32-arm64-msvc@14.1.0:
+    resolution: {integrity: sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -267,8 +267,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@14.0.4:
-    resolution: {integrity: sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==}
+  /@next/swc-win32-ia32-msvc@14.1.0:
+    resolution: {integrity: sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -276,8 +276,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@14.0.4:
-    resolution: {integrity: sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==}
+  /@next/swc-win32-x64-msvc@14.1.0:
+    resolution: {integrity: sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -735,8 +735,8 @@ packages:
     resolution: {integrity: sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==}
     dev: true
 
-  /caniuse-lite@1.0.30001570:
-    resolution: {integrity: sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==}
+  /caniuse-lite@1.0.30001587:
+    resolution: {integrity: sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==}
     dev: false
 
   /ccount@2.0.1:
@@ -1599,10 +1599,6 @@ packages:
     dependencies:
       is-glob: 4.0.3
     dev: true
-
-  /glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-    dev: false
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -2671,20 +2667,20 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-themes@0.2.1(next@14.0.4)(react-dom@18.2.0)(react@18.2.0):
+  /next-themes@0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
     peerDependencies:
       next: '*'
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /next@14.0.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==}
+  /next@14.1.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -2698,26 +2694,25 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 14.0.4
+      '@next/env': 14.1.0
       '@swc/helpers': 0.5.2
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001570
+      caniuse-lite: 1.0.30001587
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(react@18.2.0)
-      watchpack: 2.4.0
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.0.4
-      '@next/swc-darwin-x64': 14.0.4
-      '@next/swc-linux-arm64-gnu': 14.0.4
-      '@next/swc-linux-arm64-musl': 14.0.4
-      '@next/swc-linux-x64-gnu': 14.0.4
-      '@next/swc-linux-x64-musl': 14.0.4
-      '@next/swc-win32-arm64-msvc': 14.0.4
-      '@next/swc-win32-ia32-msvc': 14.0.4
-      '@next/swc-win32-x64-msvc': 14.0.4
+      '@next/swc-darwin-arm64': 14.1.0
+      '@next/swc-darwin-x64': 14.1.0
+      '@next/swc-linux-arm64-gnu': 14.1.0
+      '@next/swc-linux-arm64-musl': 14.1.0
+      '@next/swc-linux-x64-gnu': 14.1.0
+      '@next/swc-linux-x64-musl': 14.1.0
+      '@next/swc-win32-arm64-msvc': 14.1.0
+      '@next/swc-win32-ia32-msvc': 14.1.0
+      '@next/swc-win32-x64-msvc': 14.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -3761,14 +3756,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
-    dev: false
-
-  /watchpack@2.4.0:
-    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
     dev: false
 
   /web-namespaces@2.0.1:


### PR DESCRIPTION
## ℹ️ Changes to Environment Variables:

- New environment variable added `GITHUB_PAT`. This token is required during the pre-rendering of Active Projects in order to make GraphQL calls to fetch issues at organization level.

## Active Projects in Home Page (shows latest 6)

<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/da9aa840-7dbb-4b57-bdec-06beef572658">

<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/9adcb2fc-b844-42ea-b68d-e0cfc882c4b8">



## Detailed view of Active Projects (shows all)

<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/4670a995-9486-451f-b736-1389debb832d">

<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/73c3ed15-9727-476c-8ff0-9fa4bc89f54b">
