### PR TITLE
fix: fixes sorting container

### DIFF
--- a/app/leaderboard/Leaderboard.tsx
+++ b/app/leaderboard/Leaderboard.tsx
@@ -74,7 +74,7 @@ export default function Leaderboard(props: { data: LeaderboardAPIResponse }) {
                   searchParams.get("ordering") === "asc" ? "desc" : "asc",
                 );
               }}
-              className="w-96"
+              className="md:w-96"
             />
           </div>
         </div>

--- a/app/leaderboard/Leaderboard.tsx
+++ b/app/leaderboard/Leaderboard.tsx
@@ -41,7 +41,7 @@ export default function Leaderboard(props: { data: LeaderboardAPIResponse }) {
     <section className="bg-background text-foreground border-t dark:border-gray-700 border-gray-300">
       <div className="max-w-6xl mx-auto">
         <div className="mx-4 md:mx-0 mt-4 p-4 border border-primary-500 rounded-lg">
-          <div className="flex flex-col md:flex-row justify-evenly items-center md:items-start gap-4">
+          <div className="flex flex-col md:flex-row justify-evenly items-start md:items-start gap-4">
             <Search
               value={searchTerm}
               handleOnChange={(e) => setSearchTerm(e.target.value)}
@@ -74,7 +74,7 @@ export default function Leaderboard(props: { data: LeaderboardAPIResponse }) {
                   searchParams.get("ordering") === "asc" ? "desc" : "asc",
                 );
               }}
-              className="md:w-96"
+              className="w-full md:w-auto"
             />
           </div>
         </div>

--- a/components/DateRangePicker.tsx
+++ b/components/DateRangePicker.tsx
@@ -23,7 +23,7 @@ const DateRangePicker = (props: Props) => {
   const rangePresets = getRangePresets();
 
   return (
-    <div className="relative inline-block text-left whitespace-nowrap">
+    <div className="relative inline-block text-left whitespace-nowrap w-full md:w-auto">
       <Popover>
         {({ open, close }) => (
           <>


### PR DESCRIPTION
Fixes this issue of overflowing in leaderboard by adjusting it with screen.
fix issue: #253 

<img width="368" alt="Screenshot 2024-02-26 at 4 13 30 PM" src="https://github.com/coronasafe/leaderboard/assets/85889617/1e60a71f-7cee-4b85-8d2f-7fe44d57ff62">
