### PR TITLE
Updating the UI of Theme Changing button

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -1,47 +1,30 @@
 "use client";
 
 import { useTheme } from "next-themes";
+import { MdOutlineLightMode } from "react-icons/md";
+import { MdOutlineDarkMode } from "react-icons/md";
 
 export default function ThemeSwitch({ className }: { className?: string }) {
   const { theme, setTheme } = useTheme();
 
   return (
-    <div className={`flex items-center gap-2 ${className}`}>
-      {theme === "light" ? (
-        <button onClick={() => setTheme("dark")}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="h-6 w-6 fill-current text-gray-500"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
-            />
-          </svg>
-        </button>
-      ) : (
-        <button onClick={() => setTheme("light")}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="h-[26px] w-[26px] fill-current text-gray-500"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
-            />
-          </svg>
-        </button>
-      )}
+    <div className={`flex items-center justify-center ${className}`}>
+      <div
+        className={`flex cursor-pointer items-center justify-center gap-2 rounded-md bg-gray-100 p-1 dark:bg-gray-800/50`}
+      >
+        <div
+          onClick={() => setTheme("light")}
+          className={`flex items-center justify-center rounded-md bg-white p-2 dark:bg-transparent`}
+        >
+          <MdOutlineLightMode className="text-lg" />
+        </div>
+        <div
+          onClick={() => setTheme("dark")}
+          className={`flex items-center justify-center rounded-md bg-transparent p-2 dark:bg-gray-700/50`}
+        >
+          <MdOutlineDarkMode className="text-lg" />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<h1 align="center">
ISSUE #268 
</h1>

### new feature:

- Changing the UI to a more interactive one
- Removing the useState hook
- auto fixing common issues using pnpm lint-fix

### updates

- no eslint errors
![Screenshot from 2024-02-28 18-31-53](https://github.com/coronasafe/leaderboard/assets/108052802/49bc8412-1a88-43db-87f9-d8268ec06a82)

- dark theme
![Screenshot from 2024-02-28 18-38-30](https://github.com/coronasafe/leaderboard/assets/108052802/1a8a9dd6-6edb-4105-88be-c9f95c2867d3)

- light theme
![Screenshot from 2024-02-28 18-38-21](https://github.com/coronasafe/leaderboard/assets/108052802/18c23bbd-d8f0-464e-9ce1-ef686b715e64)


