### PR TITLE
update of scrollbar for pages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,31 +130,3 @@ html.dark {
   transform: translateX(0px);
   transform: translateY(0px);
 }
-
-@media (max-width: 767px) {
-  .customScrollbar::-webkit-scrollbar {
-    display: none;
-  }
-}
-
-@media (min-width: 768px) {
-  .customScrollbar::-webkit-scrollbar {
-    width: 15px;
-  }
-
-  .customScrollbar::-webkit-scrollbar-track {
-    background: var(--background);
-    border-radius: 5px;
-  }
-
-  .customScrollbar::-webkit-scrollbar-thumb {
-    background-color: var(--primary-500);
-    border-radius: 14px;
-    border: 3px solid var(--background);
-  }
-}
-
-.home-campaign-glowing-icon-glow-2 {
-  background-color: var(--primary-700);
-  filter: blur(20px);
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -130,3 +130,31 @@ html.dark {
   transform: translateX(0px);
   transform: translateY(0px);
 }
+
+@media (max-width: 767px) {
+  .customScrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .customScrollbar::-webkit-scrollbar {
+    width: 15px;
+  }
+
+  .customScrollbar::-webkit-scrollbar-track {
+    background: var(--background);
+    border-radius: 5px;
+  }
+
+  .customScrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--primary-500);
+    border-radius: 14px;
+    border: 3px solid var(--background);
+  }
+}
+
+.home-campaign-glowing-icon-glow-2 {
+  background-color: var(--primary-700);
+  filter: blur(20px);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-background text-foreground">
+      <body className="customScrollbar bg-background text-foreground">
         <div>
           <Provider>
             <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="customScrollbar bg-background text-foreground">
+      <body className="bg-background text-foreground  scrollbar scrollbar-thumb-primary-500 scrollbar-thumb-rounded-full scrollbar-w-2">
         <div>
           <Provider>
             <Navbar />

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -20,10 +20,10 @@ const Navbar = () => {
             <MenuItems />
           </div>
           <div className="align-center flex flex-row justify-center gap-4">
-            <div className="hidden items-center justify-center md:flex">
+            <div className="hidden items-center justify-center lg:flex">
               <ContributeButton />
             </div>
-            <div className="hidden items-center justify-center md:flex">
+            <div className="hidden items-center justify-center lg:flex">
               <ThemeSwitch />
             </div>
             <div
@@ -41,7 +41,7 @@ const Navbar = () => {
       </div>
       {open && (
         <div
-          className={`fixed inset-y-0 right-0 z-50 w-[53%] bg-white dark:bg-gray-800 sm:hidden ${open ? "translate-x-0" : "translate-x-full"} transition-transform duration-300 ease-in-out`}
+          className={`fixed inset-y-0 right-0 z-50 w-[53%] bg-white transition-transform duration-300 ease-in-out dark:bg-gray-800 lg:hidden`}
         >
           <div className="relative flex h-full w-full flex-col gap-5 bg-gray-300 px-6 py-4 dark:bg-gray-800">
             <div className="flex justify-end">

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "postcss": "^8.4.35",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
+    "tailwind-scrollbar": "^3.1.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ devDependencies:
   prettier-plugin-tailwindcss:
     specifier: ^0.5.11
     version: 0.5.11(prettier@3.2.5)
+  tailwind-scrollbar:
+    specifier: ^3.1.0
+    version: 3.1.0(tailwindcss@3.4.1)
   tailwindcss:
     specifier: ^3.4.1
     version: 3.4.1
@@ -3795,6 +3798,15 @@ packages:
     dependencies:
       '@pkgr/core': 0.1.1
       tslib: 2.6.2
+    dev: true
+
+  /tailwind-scrollbar@3.1.0(tailwindcss@3.4.1):
+    resolution: {integrity: sha512-pmrtDIZeHyu2idTejfV59SbaJyvp1VRjYxAjZBH0jnyrPRo6HL1kD5Glz8VPagasqr6oAx6M05+Tuw429Z8jxg==}
+    engines: {node: '>=12.13.0'}
+    peerDependencies:
+      tailwindcss: 3.x
+    dependencies:
+      tailwindcss: 3.4.1
     dev: true
 
   /tailwindcss@3.4.1:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,5 +63,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [
+    require("tailwind-scrollbar")({ nocompatible: true }),
+    require("@tailwindcss/typography"),
+  ],
 };


### PR DESCRIPTION
<h1 align="center">Fixes #279 </h1>

![Untitled drawing (6)](https://github.com/coronasafe/leaderboard/assets/108052802/984b11a4-297b-4e94-b4b4-5ea24312d3c9)


### Added Feature

- Enhance the scrollbar functionality by dynamically adapting its thumb color to the current color theme
- hiding the scrollbar on devices smaller than 767px, fostering a mobile-centric experience that prioritizes seamless navigation and user interaction