### PR TITLE
Updated script to skip cloning if already cloned

### DIFF
--- a/load-org-data.sh
+++ b/load-org-data.sh
@@ -1,6 +1,6 @@
 : "${FIXTURES_SOURCE:=https://github.com/coronasafe/leaderboard-data.git}"
 
-if [ -d "data-repo/.git" ]; then
+if [ -d "data-repo/.git" ] && (cd data-repo && git remote -v | grep -q 'upstream'); then
   echo "Updating existing data repository..."
   
   cd data-repo

--- a/load-org-data.sh
+++ b/load-org-data.sh
@@ -1,16 +1,31 @@
 : "${FIXTURES_SOURCE:=https://github.com/coronasafe/leaderboard-data.git}"
 
-rm -rf data-repo
-mkdir data-repo
-cd data-repo
+if [ -d "data-repo/.git" ]; then
+  echo "Updating existing data repository..."
+  
+  cd data-repo
+  
+  git fetch upstream
+  git checkout --force main
+  git reset --hard main
+  
+  cd ..
+else
+  echo "Cloning data repository for the first time..."
 
-git init
-git remote add --mirror=fetch origin ${FIXTURES_SOURCE}
-git config core.sparseCheckout true
-
-echo "data/" >> .git/info/sparse-checkout
-echo "contributors/" >> .git/info/sparse-checkout
-echo "config/" >> .git/info/sparse-checkout
-
-git pull origin main
+  rm -rf data-repo
+  mkdir data-repo
+  cd data-repo
+  
+  git init
+  git remote add --mirror=fetch upstream ${FIXTURES_SOURCE}
+  git config core.sparseCheckout true
+  
+  echo "data/" >> .git/info/sparse-checkout
+  echo "contributors/" >> .git/info/sparse-checkout
+  echo "config/" >> .git/info/sparse-checkout
+  
+  git pull upstream main
+  cd ..
+fi
 

--- a/load-org-data.sh
+++ b/load-org-data.sh
@@ -12,18 +12,13 @@ if [ -d "data-repo/.git" ] && (cd data-repo && git remote -v | grep -q 'upstream
   cd ..
 else
   echo "Cloning data repository for the first time..."
-
+  
   rm -rf data-repo
-  mkdir data-repo
+  git clone ${FIXTURES_SOURCE} data-repo
   cd data-repo
   
-  git init
-  git remote add --mirror=fetch upstream ${FIXTURES_SOURCE}
-  git config core.sparseCheckout true
-  
-  echo "data/" >> .git/info/sparse-checkout
-  echo "contributors/" >> .git/info/sparse-checkout
-  echo "config/" >> .git/info/sparse-checkout
+  git remote add upstream ${FIXTURES_SOURCE}
+  git remote remove origin 
   
   git pull upstream main
   cd ..


### PR DESCRIPTION
fixes - #334 

- Renamed remote name from origin to upsteam 
- Updated script to skip cloning if already cloned