### PR TITLE
fix: UI improvements to Contributor Badge Popup

### DIFF
--- a/components/contributors/BadgeIcons.tsx
+++ b/components/contributors/BadgeIcons.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 
 function useOnClickOutside(
   ref: RefObject<HTMLInputElement>,
-  handler: () => void,
+  handler: () => void
 ) {
   useEffect(() => {
     const listener = (event: any) => {
@@ -135,14 +135,17 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
           <div className="px-4 pb-4 pt-2">
             <p className="pb-2 font-bold">{skill.label}</p>
             <div className="space-y-1 text-sm">
-            {skill.levels.map((level: any, index: number) => (
+              {skill.levels.map((level: any, index: number) => (
                 <div
                   key={level.value}
                   className="flex items-center font-medium text-secondary-400"
                 >
                   <p
                     className={`shrink-0 rounded px-1 py-0.5 ${
-                      index <= skill.levels.findIndex((l) => l.value === skill.currentLevel?.value)
+                      index <=
+                      skill.levels.findIndex(
+                        (l) => l.value === skill.currentLevel?.value
+                      )
                         ? "bg-green-400 text-white"
                         : "bg-secondary-700 opacity-40 grayscale"
                     }`}
@@ -152,7 +155,10 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
                   <div className="grow pl-4">
                     <p
                       className={`flex items-center ${
-                        index <= skill.levels.findIndex((l) => l.value === skill.currentLevel?.value)
+                        index <=
+                        skill.levels.findIndex(
+                          (l) => l.value === skill.currentLevel?.value
+                        )
                           ? "text-green-500"
                           : "opacity-40 grayscale"
                       }`}

--- a/components/contributors/BadgeIcons.tsx
+++ b/components/contributors/BadgeIcons.tsx
@@ -83,7 +83,7 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
               : "invisible opacity-0"
           }`}
         >
-          <div className="flex items-center justify-center rounded-t-lg border-b border-secondary-700 bg-secondary-900 px-4 py-3">
+          <div className="flex items-center justify-center rounded-t-lg border-b border-secondary-700 bg-secondary-950 px-4 py-3">
             <div className="relative h-24 w-24">
               {skill.currentLevel && (
                 <>
@@ -135,16 +135,16 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
           <div className="px-4 pb-4 pt-2">
             <p className="pb-2 font-bold">{skill.label}</p>
             <div className="space-y-1 text-sm">
-              {skill.levels.map((level: any) => (
+            {skill.levels.map((level: any, index: number) => (
                 <div
                   key={level.value}
                   className="flex items-center font-medium text-secondary-400"
                 >
                   <p
-                    className={`shrink-0 rounded bg-secondary-700 px-1 py-0.5 ${
-                      skill.currentLevel?.value ?? -1 >= level.value
+                    className={`shrink-0 rounded px-1 py-0.5 ${
+                      index <= skill.levels.findIndex((l) => l.value === skill.currentLevel?.value)
                         ? "bg-green-400 text-white"
-                        : ""
+                        : "bg-secondary-700 opacity-40 grayscale"
                     }`}
                   >
                     {level.label}
@@ -152,9 +152,9 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
                   <div className="grow pl-4">
                     <p
                       className={`flex items-center ${
-                        skill.currentLevel?.value ?? -1 >= level.value
+                        index <= skill.levels.findIndex((l) => l.value === skill.currentLevel?.value)
                           ? "text-green-500"
-                          : ""
+                          : "opacity-40 grayscale"
                       }`}
                     >
                       {level.description}

--- a/components/contributors/BadgeIcons.tsx
+++ b/components/contributors/BadgeIcons.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 
 function useOnClickOutside(
   ref: RefObject<HTMLInputElement>,
-  handler: () => void
+  handler: () => void,
 ) {
   useEffect(() => {
     const listener = (event: any) => {
@@ -144,7 +144,7 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
                     className={`shrink-0 rounded px-1 py-0.5 ${
                       index <=
                       skill.levels.findIndex(
-                        (l) => l.value === skill.currentLevel?.value
+                        (l) => l.value === skill.currentLevel?.value,
                       )
                         ? "bg-green-400 text-white"
                         : "bg-secondary-700 opacity-40 grayscale"
@@ -157,7 +157,7 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
                       className={`flex items-center ${
                         index <=
                         skill.levels.findIndex(
-                          (l) => l.value === skill.currentLevel?.value
+                          (l) => l.value === skill.currentLevel?.value,
                         )
                           ? "text-green-500"
                           : "opacity-40 grayscale"


### PR DESCRIPTION
fix #298 
Now badge popup has visual separation from the background
And badge levels are only green if that level was attained. Unobtained levels are gray / faded out

Before Changes -
![Before1](https://github.com/coronasafe/leaderboard/assets/92617480/47a06592-9f8e-48ad-841c-1082c97817bc)
![Before2](https://github.com/coronasafe/leaderboard/assets/92617480/021500a9-28ff-4506-bab3-b862fc850d18)

After Changes-
![After1](https://github.com/coronasafe/leaderboard/assets/92617480/5c497526-fbc2-4534-8740-fb85273a327d)
![After2](https://github.com/coronasafe/leaderboard/assets/92617480/5c220675-ae18-4cea-a845-9305f1887918)
