### PR TITLE
Prevents duplicate events from merging with existing events.

### DIFF
--- a/scraper/src/github.py
+++ b/scraper/src/github.py
@@ -455,7 +455,11 @@ class GitHubScraper:
             self.log.debug(f"Merging user data for {user}")
             old_data = self.load_user_data(user)
             data = self.data.get(user)
-            data["activity"].extend(old_data["activity"])
+            new_unique_events = []
+            for event in data["activity"]:
+                if event not in old_data["activity"]:
+                    new_unique_events.append(event)
+            data["activity"] = new_unique_events + old_data["activity"]
             self.save_user_data(user, data)
         self.log.info("Updated data")
 

--- a/scripts/migrations/002_migrate_github_activity_timestamps.js
+++ b/scripts/migrations/002_migrate_github_activity_timestamps.js
@@ -9,7 +9,7 @@ import path from "path";
 const githubDataPath = path.join(__dirname, "data/github");
 
 async function main() {
-  const files = await readdir("data/github");
+  const files = await readdir(githubDataPath);
   console.log(`Processing ${files.length} files...`);
 
   await Promise.all(

--- a/scripts/migrations/003_migration_to_remove_duplicate_activities.js
+++ b/scripts/migrations/003_migration_to_remove_duplicate_activities.js
@@ -1,0 +1,52 @@
+/**
+ * Migration to remove duplicate activities from the users data.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+function removeDuplicates(data) {
+  const uniqueActivities = [];
+  const seenActivities = new Set();
+
+  data.activity.forEach((activity) => {
+    const activityKey = JSON.stringify(activity);
+
+    if (!seenActivities.has(activityKey)) {
+      uniqueActivities.push(activity);
+      seenActivities.add(activityKey);
+    }
+  });
+
+  data.activity = uniqueActivities;
+  return JSON.stringify(data, null, 2);
+}
+
+function main() {
+  const dir = path.join(__dirname, "../../data-repo/data/github");
+  fs.readdir(dir, function (err, files) {
+    if (err) {
+      return console.log(err);
+    }
+
+    files.forEach((file) => {
+      const file_to_update = path.join(dir, file);
+
+      fs.readFile(file_to_update, "utf8", function (err, data) {
+        if (err) {
+          return console.log(err);
+        }
+        const updatedData = removeDuplicates(JSON.parse(data));
+        fs.writeFile(file_to_update, updatedData, function (err) {
+          if (err) {
+            return console.log(err);
+          }
+
+          console.log(`Updated ${file}`);
+        });
+      });
+    });
+  });
+}
+
+main();

--- a/scripts/migrations/003_migration_to_remove_duplicate_activities.js
+++ b/scripts/migrations/003_migration_to_remove_duplicate_activities.js
@@ -8,7 +8,7 @@ const path = require("path");
 const githubDataPath = path.join(__dirname, "../../data-repo/data/github");
 
 async function main() {
-  const files = await readdir("../../data-repo/data/github");
+  const files = await readdir(githubDataPath);
   console.log(`Processing ${files.length} files...`);
 
   await Promise.all(


### PR DESCRIPTION
fixes #324  

- Created a script for cleaning up existing data.
- Prevents duplicate events from getting merged.

linked pr:
https://github.com/coronasafe/leaderboard-data/pull/29