### PR TITLE
Migrate fetchGitHubReleases Method to Use Octokit for GitHub API Interactions

### DIFF
--- a/app/api/leaderboard/functions.ts
+++ b/app/api/leaderboard/functions.ts
@@ -1,6 +1,10 @@
-import { LeaderboardSortKey, ReleasesResponse } from "@/lib/types";
+import {
+  LeaderboardSortKey,
+  ReleasesResponse,
+  LeaderboardAPIResponse,
+  Release,
+} from "@/lib/types";
 import { getContributors } from "@/lib/api";
-import { Repository, LeaderboardAPIResponse, Release } from "@/lib/types";
 import { env } from "@/env.mjs";
 import { getGitHubAccessToken } from "@/lib/octokit";
 import octokit from "@/lib/octokit";

--- a/app/api/leaderboard/functions.ts
+++ b/app/api/leaderboard/functions.ts
@@ -81,7 +81,7 @@ export default async function fetchGitHubReleases(
                       login
                       avatarUrl
                     }
-                    mentions (first: 10) {
+                    mentions (first: 100) {
                       nodes {
                         login
                         avatarUrl

--- a/app/api/leaderboard/functions.ts
+++ b/app/api/leaderboard/functions.ts
@@ -68,7 +68,7 @@ export default async function fetchGitHubReleases(
     query: `
         query GetReleases($org: String!) {
           organization(login: $org) {
-            repositories(first: 100) {
+            repositories(first: 100, orderBy: { field: UPDATED_AT, direction: DESC })  {
               nodes {
                 name
                 releases(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {

--- a/app/releases/page.tsx
+++ b/app/releases/page.tsx
@@ -65,7 +65,7 @@ export default async function Page() {
             <div className="p-6 pt-0">
               <p>Contributors - </p>
               <div className="mt-3 flex gap-2">
-                <div className="grid grid-cols-3 gap-3 md:grid-cols-10">
+                <div className="grid grid-cols-5 gap-3 md:grid-cols-10">
                   {release.mentions.nodes.map((contributor) => (
                     <Link
                       href={`https://github.com/${contributor.login}`}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,7 +128,6 @@ export interface Organization {
 
 // GitHubResponse interface
 export interface ReleasesResponse {
-  data: any;
   organization: Organization;
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",
+    "@octokit/graphql": "^8.0.1",
     "@t3-oss/env-nextjs": "^0.9.2",
     "clsx": "^1.2.1",
     "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",
-    "@octokit/graphql": "^8.0.1",
     "@t3-oss/env-nextjs": "^0.9.2",
     "clsx": "^1.2.1",
     "date-fns": "^2.30.0",


### PR DESCRIPTION

### Description
This pull request addresses the issue by migrating the fetchGitHubReleases method to use Octokit instead of the traditional fetch to interact with GitHub APIs. I have made several modifications as follows:

- Utilized `Octokit.graphql` for interacting with GitHub API.
- Replaced the conventional for loop with a `flatMap`.
- Adjusted the `ReleasesResponse` type interface to align with the response type from Octokit GraphQL.
- Install `@octokit/graphql`

Fixes #347 

### Type of change

1. Integration of `Octokit.graphql` for GitHub API interaction.
2. Implementation of `flatMap` for improved efficiency.
3. Refactoring of `ReleasesResponse` interface to match Octokit GraphQL response structure.



