### PR TITLE
Add Organization Start Date Display and Tooltip with Total Weeks on Home Page

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ NEXT_PUBLIC_ORG_INFO=Open Healthcare Network is a free and open-source disaster 
 NEXT_PUBLIC_ORG_LOGO=/logo.webp 
 NEXT_PUBLIC_GITHUB_ORG=coronasafe
 NEXT_PUBLIC_SLACK_URL=https://slack.ohc.network
+NEXT_PUBLIC_ORG_START_DATE=2020-03-08
 
 ## -- SEO details -- ##
 NEXT_PUBLIC_META_TITLE=Open Healthcare Network

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { Suspense } from "react";
 import { env } from "@/env.mjs";
 import CommunityEngagemet from "@/app/CommunityEngagementSummary";
 import { differenceInWeeks, parseISO } from "date-fns";
+import { formatDate } from "@/lib/utils";
 
 export default async function Home() {
   const contributors = (await getContributors())
@@ -22,8 +23,6 @@ export default async function Home() {
     .sort((a, b) => b.weekSummary.points - a.weekSummary.points);
 
   const startDate = parseISO(env.NEXT_PUBLIC_ORG_START_DATE);
-  const currentDate = new Date();
-  const totalWeeks = differenceInWeeks(currentDate, startDate);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -171,10 +170,10 @@ export default async function Home() {
                       <span className="text-secondary-600 dark:text-secondary-300">
                         <time
                           dateTime={env.NEXT_PUBLIC_ORG_START_DATE}
-                          title={`Since ${startDate.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}`}
-                          className="underline"
+                          title={`Since ${formatDate(startDate)}}`}
+                          className="underline underline-offset-4"
                         >
-                          Week {totalWeeks}
+                          Week {differenceInWeeks(new Date(), startDate)}
                         </time>
                       </span>
                     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import ReleaseSection from "@/components/releases/ReleaseSection";
 import { Suspense } from "react";
 import { env } from "@/env.mjs";
 import CommunityEngagemet from "@/app/CommunityEngagementSummary";
+import { differenceInWeeks, parseISO } from "date-fns";
 
 export default async function Home() {
   const contributors = (await getContributors())
@@ -19,6 +20,11 @@ export default async function Home() {
           .includes(contributor.role) ?? true,
     )
     .sort((a, b) => b.weekSummary.points - a.weekSummary.points);
+
+  const startDate = parseISO(env.NEXT_PUBLIC_ORG_START_DATE);
+  const currentDate = new Date();
+  const totalWeeks = differenceInWeeks(currentDate, startDate);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <section className="bg-background">
@@ -163,7 +169,13 @@ export default async function Home() {
                     <div className="flex flex-col justify-between rounded-t-lg border-b border-secondary-300 bg-secondary-100 px-6 py-4 dark:border-secondary-700 dark:bg-secondary-800 md:flex-row md:items-center">
                       <h4 className="font-bold">Leaderboard</h4>
                       <span className="text-secondary-600 dark:text-secondary-300">
-                        last 7 days
+                        <time
+                          dateTime={env.NEXT_PUBLIC_ORG_START_DATE}
+                          title={`Since ${startDate.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}`}
+                          className="underline"
+                        >
+                          Week {totalWeeks}
+                        </time>
                       </span>
                     </div>
 

--- a/env.mjs
+++ b/env.mjs
@@ -12,6 +12,7 @@ export const env = createEnv({
     NEXT_PUBLIC_ORG_LOGO: z.string(),
     NEXT_PUBLIC_GITHUB_ORG: z.string(),
     NEXT_PUBLIC_SLACK_URL: z.string().url(),
+    NEXT_PUBLIC_ORG_START_DATE: z.string(),
 
     // SEO details
     NEXT_PUBLIC_META_TITLE: z.string(),
@@ -36,6 +37,7 @@ export const env = createEnv({
     NEXT_PUBLIC_META_URL: process.env.NEXT_PUBLIC_META_URL,
     NEXT_PUBLIC_PAGE_TITLE: process.env.NEXT_PUBLIC_PAGE_TITLE,
     NEXT_PUBLIC_CONTRIBUTORS_INFO: process.env.NEXT_PUBLIC_CONTRIBUTORS_INFO,
+    NEXT_PUBLIC_ORG_START_DATE: process.env.NEXT_PUBLIC_ORG_START_DATE,
     NEXT_PUBLIC_LEADERBOARD_DEFAULT_ROLES:
       process.env.NEXT_PUBLIC_LEADERBOARD_DEFAULT_ROLES,
     GITHUB_PAT:


### PR DESCRIPTION
# Description
Implemented the following action items based on the provided issue statement:

1. Created an environment variable NEXT_PUBLIC_ORG_START_DATE.
2. Displayed the number of weeks since the configured start date on the home page.
3. Added functionality to show the organization's start date itself as a tooltip on hover.

Fixes #327 

## Type of change
Added `NEXT_PUBLIC_ORG_START_DATE` to the `.env` file.
Utilized `date-fns` library for updating the home route to calculate and display the required date information.
