### PR TITLE
fix github og images where repo starts with a period

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,11 @@ const nextConfig = {
         protocol: "https",
         hostname: "opengraph.githubassets.com",
       },
+      {
+        protocol: "https",
+        hostname: "opengraph.githubassets.com",
+        pathname: "/**/.*/**"
+      },
     ],
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -15,10 +15,12 @@ const nextConfig = {
         protocol: "https",
         hostname: "opengraph.githubassets.com",
       },
+      // fix for crash if a path starts with period
+      // ref: https://github.com/coronasafe/leaderboard/pull/376
       {
         protocol: "https",
         hostname: "opengraph.githubassets.com",
-        pathname: "/**/.*/**"
+        pathname: "/**/.*/**",
       },
     ],
   },


### PR DESCRIPTION
Fixes the issue where the period in the path will fail to match the github opengraph remotePatterns

this resulted in a crash on local:
![image](https://github.com/coronasafe/leaderboard/assets/46787056/2e6770a0-78d3-49ad-8a69-3cd6b603bf1e)

and failed to generate image on deployment:
![image](https://github.com/coronasafe/leaderboard/assets/46787056/263accde-c3a0-49dc-8c70-a9a8d3a075ac)

after fix:
<img width="700" alt="image" src="https://github.com/coronasafe/leaderboard/assets/46787056/0513d0a4-0fff-4cea-9699-3e08955fb79a">
