### PR TITLE
Nav bar item highlight feature added | issue #378

### DIFF
--- a/components/navbar/Logo.tsx
+++ b/components/navbar/Logo.tsx
@@ -1,14 +1,9 @@
 import Link from "next/link";
 import { env } from "@/env.mjs";
 
-const Logo = (props: any) => {
+const Logo = () => {
   return (
-    <Link
-      href="/"
-      onClick={() => {
-        props.setActiveIdx(-1);
-      }}
-    >
+    <Link href="/">
       <div className="flex flex-col  items-end justify-end">
         <p className="text-xl font-bold text-primary-500 dark:text-primary-300 md:text-4xl">
           {env.NEXT_PUBLIC_ORG_NAME || "Open Source"}

--- a/components/navbar/Logo.tsx
+++ b/components/navbar/Logo.tsx
@@ -1,9 +1,14 @@
 import Link from "next/link";
 import { env } from "@/env.mjs";
 
-const Logo = () => {
+const Logo = (props: any) => {
   return (
-    <Link href="/">
+    <Link
+      href="/"
+      onClick={() => {
+        props.setActiveIdx(-1);
+      }}
+    >
       <div className="flex flex-col  items-end justify-end">
         <p className="text-xl font-bold text-primary-500 dark:text-primary-300 md:text-4xl">
           {env.NEXT_PUBLIC_ORG_NAME || "Open Source"}

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -27,9 +27,9 @@ export default function Navbar() {
           <Logo />
 
           <div className="hidden flex-row items-center justify-between gap-3 rounded bg-secondary-100 font-semibold dark:bg-secondary-800 md:rounded-full md:px-6 md:py-1 lg:flex">
-            {Object.entries(MenuItems).map(([href, label], index) => (
+            {Object.entries(MenuItems).map(([href, label]) => (
               <Link
-                key={index}
+                key={href}
                 href={href}
                 className={
                   "cursor-pointer text-sm transition-all hover:text-primary-500 hover:underline hover:dark:text-primary-300 md:p-2 md:text-base " +
@@ -73,12 +73,10 @@ export default function Navbar() {
               </button>
             </div>
             <div className="flex flex-col items-center justify-center gap-2 md:px-4 md:py-2">
-              {Object.entries(MenuItems).map(([href, label], index) => (
+              {Object.entries(MenuItems).map(([href, label]) => (
                 <Link
-                  key={index}
-                  onClick={() => {
-                    setOpen(!open);
-                  }}
+                  key={href}
+                  onClick={() => setOpen(!open)}
                   href={href}
                   className={
                     "cursor-pointer p-1 text-sm hover:text-primary-500 hover:underline md:p-2 md:text-base " +

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -6,7 +6,8 @@ import ContributeButton from "./ContributeButton";
 import Logo from "./Logo";
 import { RxHamburgerMenu } from "react-icons/rx";
 import { IoClose } from "react-icons/io5";
-import { useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
 
 const MenuItems = {
   "/leaderboard": "Leaderboard",
@@ -17,32 +18,28 @@ const MenuItems = {
 };
 
 export default function Navbar() {
-  const [activeIdx, setActiveIdx] = useState(-1);
   const [open, setOpen] = useState(false);
-  const router = useRouter();
+  const pathname = usePathname();
   return (
     <>
       <nav className="sticky top-0 z-10 border-b border-secondary-300 bg-background px-4 py-1 shadow-md dark:border-secondary-700 sm:shadow-lg">
         <div className="mx-auto flex max-w-7xl items-center justify-between xl:px-3">
-          <Logo setActiveIdx={setActiveIdx} />
+          <Logo />
 
           <div className="hidden flex-row items-center justify-between gap-3 rounded bg-secondary-100 font-semibold dark:bg-secondary-800 md:rounded-full md:px-6 md:py-1 lg:flex">
             {Object.entries(MenuItems).map(([href, label], index) => (
-              <div
+              <Link
                 key={index}
-                onClick={() => {
-                  setActiveIdx(index);
-                  router.push(href);
-                }}
+                href={href}
                 className={
                   "cursor-pointer text-sm transition-all hover:text-primary-500 hover:underline hover:dark:text-primary-300 md:p-2 md:text-base " +
-                  (activeIdx == index
+                  (pathname === href
                     ? "text-primary-500 dark:text-primary-300"
                     : "")
                 }
               >
                 {label}
-              </div>
+              </Link>
             ))}
           </div>
 
@@ -77,22 +74,21 @@ export default function Navbar() {
             </div>
             <div className="flex flex-col items-center justify-center gap-2 md:px-4 md:py-2">
               {Object.entries(MenuItems).map(([href, label], index) => (
-                <div
+                <Link
                   key={index}
                   onClick={() => {
-                    setActiveIdx(index);
-                    router.push(href);
                     setOpen(!open);
                   }}
+                  href={href}
                   className={
                     "cursor-pointer p-1 text-sm hover:text-primary-500 hover:underline md:p-2 md:text-base " +
-                    (activeIdx == index
+                    (pathname === href
                       ? "text-primary-500 dark:text-primary-300"
                       : "")
                   }
                 >
                   {label}
-                </div>
+                </Link>
               ))}
             </div>
             <ContributeButton />

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -6,8 +6,7 @@ import ContributeButton from "./ContributeButton";
 import Logo from "./Logo";
 import { RxHamburgerMenu } from "react-icons/rx";
 import { IoClose } from "react-icons/io5";
-import Sidebar from "./Sidebar";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 const MenuItems = {
   "/leaderboard": "Leaderboard",
@@ -18,23 +17,32 @@ const MenuItems = {
 };
 
 export default function Navbar() {
+  const [activeIdx, setActiveIdx] = useState(-1);
   const [open, setOpen] = useState(false);
-
+  const router = useRouter();
   return (
     <>
       <nav className="sticky top-0 z-10 border-b border-secondary-300 bg-background px-4 py-1 shadow-md dark:border-secondary-700 sm:shadow-lg">
         <div className="mx-auto flex max-w-7xl items-center justify-between xl:px-3">
-          <Logo />
+          <Logo setActiveIdx={setActiveIdx} />
 
           <div className="hidden flex-row items-center justify-between gap-3 rounded bg-secondary-100 font-semibold dark:bg-secondary-800 md:rounded-full md:px-6 md:py-1 lg:flex">
-            {Object.entries(MenuItems).map(([href, label]) => (
-              <Link
-                key={href}
-                className="text-sm transition-all hover:text-primary-500 hover:underline hover:dark:text-primary-300 md:p-2 md:text-base"
-                href={href}
+            {Object.entries(MenuItems).map(([href, label], index) => (
+              <div
+                key={index}
+                onClick={() => {
+                  setActiveIdx(index);
+                  router.push(href);
+                }}
+                className={
+                  "cursor-pointer text-sm transition-all hover:text-primary-500 hover:underline hover:dark:text-primary-300 md:p-2 md:text-base " +
+                  (activeIdx == index
+                    ? "text-primary-500 dark:text-primary-300"
+                    : "")
+                }
               >
                 {label}
-              </Link>
+              </div>
             ))}
           </div>
 
@@ -68,14 +76,23 @@ export default function Navbar() {
               </button>
             </div>
             <div className="flex flex-col items-center justify-center gap-2 md:px-4 md:py-2">
-              {Object.entries(MenuItems).map(([href, label]) => (
-                <Link
-                  key={href}
-                  href={href}
-                  className="p-1 text-sm hover:text-primary-500 hover:underline md:p-2 md:text-base"
+              {Object.entries(MenuItems).map(([href, label], index) => (
+                <div
+                  key={index}
+                  onClick={() => {
+                    setActiveIdx(index);
+                    router.push(href);
+                    setOpen(!open);
+                  }}
+                  className={
+                    "cursor-pointer p-1 text-sm hover:text-primary-500 hover:underline md:p-2 md:text-base " +
+                    (activeIdx == index
+                      ? "text-primary-500 dark:text-primary-300"
+                      : "")
+                  }
                 >
                   {label}
-                </Link>
+                </div>
               ))}
             </div>
             <ContributeButton />


### PR DESCRIPTION
# Closes #378 

## Shows selected item in nav bar
Now highlights selected item in nav bar in both dark, light mode. Small and Large screen. 
![image](https://github.com/coronasafe/leaderboard/assets/83684042/8b9a1aea-ce4c-4f41-80f8-6f5fe3299534)
![image](https://github.com/coronasafe/leaderboard/assets/83684042/ff0c5d15-3994-432c-ad37-8395ffb7b914)
![image](https://github.com/coronasafe/leaderboard/assets/83684042/f3491875-d0b1-4e6b-8795-4ae3743be49c)
![image](https://github.com/coronasafe/leaderboard/assets/83684042/74fce9a1-7c98-492e-b7d5-7a50745f7844)

## In phone screen, on clicking item in sidebar, it closes the sidebar.