### PR TITLE
Cache computed values to reduce build times

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -70,9 +70,15 @@ async function getSlackMessages(slackId: string) {
   }
 }
 
-export async function getContributorsSlugs() {
-  const files = await readdir(`${root}`);
-  return files.map((file) => ({ file }));
+let contributorSlugs: Awaited<ReturnType<typeof getContributorsSlugs>> | null =
+  null;
+
+export async function getContributorsSlugs(): Promise<{ file: string }[]> {
+  if (!contributorSlugs) {
+    const files = await readdir(`${root}`);
+    contributorSlugs = files.map((file) => ({ file }));
+  }
+  return contributorSlugs;
 }
 
 export async function getContributorBySlug(file: string, detail = false) {
@@ -183,11 +189,17 @@ export async function getContributorBySlug(file: string, detail = false) {
   } as Contributor & { summarize: typeof summarize };
 }
 
-export async function getContributors(detail = false) {
-  const slugs = await getContributorsSlugs();
-  return Promise.all(
-    slugs.map((path) => getContributorBySlug(path.file, detail)),
-  );
+let contributors: Awaited<ReturnType<typeof getContributorBySlug>>[] | null =
+  null;
+
+export async function getContributors() {
+  if (!contributors) {
+    const slugs = await getContributorsSlugs();
+    contributors = await Promise.all(
+      slugs.map((path) => getContributorBySlug(path.file)),
+    );
+  }
+  return contributors;
 }
 
 function getCalendarData(activity: Activity[]) {


### PR DESCRIPTION
- Fixes #382 

### Before (local build) [1m 17s]
<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/1d76a700-fde4-4da5-85fd-40f3a26e6d1f">

### After (local build) [17s; 4.5x faster]
<img width="1822" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/b4ffe516-b520-4561-80a1-1951a6b395f3">


### Before (vercel builds) [7m 28s]

<img width="1249" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/957cc649-53c3-44ec-b92a-e1d923788fbe">


### After (vercel builds) [1m 49s; 4.1x faster]

<img width="1264" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/f43d3cdb-b749-4e12-abe8-fb31ec33e016">

