### PR TITLE
fix for organisation logo and favicon

### DIFF
--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,1 +1,1 @@
-data-repo/config/assets/favicon.ico
+../data-repo/config/assets/favicon.ico

--- a/public/logo.webp
+++ b/public/logo.webp
@@ -1,1 +1,1 @@
-data-repo/config/assets/logo.webp
+../data-repo/config/assets/logo.webp


### PR DESCRIPTION
- fixes #385

The issue was here at symlink
The both `favicon` and `logo.webp` were pointing to wrong location.
```➜  public git:(main) l 
total 12K
drwxrwxr-x  3 mrsp mrsp 4.0K Mar 18 11:34 .
drwxrwxr-x 14 mrsp mrsp 4.0K Mar 18 11:34 ..
lrwxrwxrwx  1 mrsp mrsp   35 Mar 18 11:34 favicon.ico -> data-repo/config/assets/favicon.ico
drwxrwxr-x  6 mrsp mrsp 4.0K Mar 18 11:34 images
lrwxrwxrwx  1 mrsp mrsp   33 Mar 18 11:34 logo.webp -> data-repo/config/assets/logo.webp
```
## FIX
```
lrwxrwxrwx  1 mrsp mrsp   38 Mar 18 12:17 favicon.ico -> ../data-repo/config/assets/favicon.ico
drwxrwxr-x  6 mrsp mrsp 4.0K Mar 11 19:10 images
lrwxrwxrwx  1 mrsp mrsp   36 Mar 18 12:16 logo.webp -> ../data-repo/config/assets/logo.webp
```
