### PR TITLE
Fixes issue with current level resolver for GA if not achieved

### DIFF
--- a/config/GraduateAttributes.ts
+++ b/config/GraduateAttributes.ts
@@ -254,7 +254,9 @@ export type GraduateAttribute = {
 let resolveLevel = (attribute: GraduateAttribute, value: number) => {
   return {
     ...attribute,
-    currentLevel: attribute.levels.reduce((p, v) => (value >= v.value ? v : p)),
+    currentLevel: value
+      ? attribute.levels.reduce((p, v) => (value >= v.value ? v : p))
+      : undefined,
   };
 };
 


### PR DESCRIPTION
Fixes issue with current level resolver for graduate attributes taking first level automatically if none achieved.


**Before:**
![image](https://github.com/coronasafe/leaderboard/assets/25143503/1b80c74f-b40b-4fe8-8074-6046b19bedc2)

**After:**
<img width="930" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/d00963d9-1eaa-45d0-a318-9144fb76d98b">

cc: @bodhish 
