### PR TITLE
Adds script for pulling historical data for an org.

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,6 +3,7 @@ import matter from "gray-matter";
 import { Activity, ActivityData, Contributor, Highlights } from "./types";
 import { padZero } from "./utils";
 import { readFile, readdir } from "fs/promises";
+import { existsSync } from "fs";
 
 const root = join(process.cwd(), "data-repo/contributors");
 const slackRoot = join(process.cwd(), "data-repo/data/slack");
@@ -35,7 +36,10 @@ function formatSlugJSON(slug: string) {
 }
 
 async function getSlackSlugs() {
-  const files = await readdir(`${slackRoot}`);
+  if (!existsSync(slackRoot)) {
+    return {};
+  }
+  const files = await readdir(slackRoot);
   return Object.fromEntries(files.map((file) => [formatSlugJSON(file), file]));
 }
 

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,2 @@
+logo.webp
+favicon.ico

--- a/scripts/generateNewContributors.js
+++ b/scripts/generateNewContributors.js
@@ -1,4 +1,5 @@
-let fs = require("fs");
+const fs = require("fs");
+const { join } = require("path");
 
 function generateContent(name, github) {
   return `---
@@ -16,14 +17,16 @@ Still waiting for this
 `;
 }
 
+const basePath = join(process.env.DATA_REPO || process.cwd());
+
 function getNewContributors() {
   let newContributors = new Set();
 
-  fs.readdirSync("./data/github").forEach((file) => {
+  fs.readdirSync(join(basePath, "data/github")).forEach((file) => {
     newContributors.add(file.split(".")[0]);
   });
 
-  fs.readdirSync("./contributors").forEach((file) => {
+  fs.readdirSync(join(basePath, "contributors")).forEach((file) => {
     newContributors.delete(file.split(".")[0]);
   });
 
@@ -54,7 +57,7 @@ function main() {
       .then((data) => {
         if (data.name === null) data.name = data.login;
         fs.writeFile(
-          `./contributors/${data.login}.md`,
+          join(basePath, `contributors/${data.login}.md`),
           generateContent(data.name, data.login),
           (err) => {
             if (err) throw err;

--- a/scripts/pullHistoricalGitHubActivities.js
+++ b/scripts/pullHistoricalGitHubActivities.js
@@ -1,0 +1,207 @@
+/**
+ * Script to populate the data-repo with historical information from GitHub.
+ *
+ * Supports populating the ollowing activity types:
+ *
+ * - [x] issue_opened
+ * - [ ] issue_closed
+ * - [x] pr_opened
+ * - [x] pr_merged
+ *
+ * !! NOTE !!
+ * Overwrites any existing activity data present for a user. Does not support
+ * merging with existing activity data and removing duplicates yet.
+ */
+
+const { join } = require("path");
+const { writeFile, mkdir } = require("fs/promises");
+const { Octokit } = require("octokit");
+
+const basePath = join(process.env.DATA_REPO || process.cwd(), "data/github");
+console.info(`Data will be written to: '${basePath}'`);
+
+const org = process.env.GITHUB_ORG;
+const token = process.env.GITHUB_TOKEN;
+
+if (!org) {
+  throw Error(
+    "'GITHUB_ORG' environment needs to be set with a GitHub Organization (e.g.: 'coronasafe').",
+  );
+}
+
+if (!token) {
+  throw Error(
+    "'GITHUB_TOKEN' environment needs to be set with a GitHub Access Token.",
+  );
+}
+
+const blacklistedAccounts = ["dependabot", "snykbot", "codecov-commenter"];
+
+const octokit = new Octokit({ auth: token });
+
+const repositoryIterator = octokit.graphql.paginate.iterator(
+  `query paginate($cursor: String, $org: String!) {
+    organization(login: $org) {
+      repositories(first: 100, orderBy: { field: UPDATED_AT, direction: DESC }, after: $cursor)  {
+        nodes {
+          name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }`,
+  { org },
+);
+
+const getIssues = async (repo) => {
+  const { repository } = await octokit.graphql.paginate(
+    `query paginate($cursor: String, $org: String!, $repo: String!) {
+      repository(owner: $org, name: $repo) {
+        issues(first: 100, after: $cursor) {
+          nodes {
+            number
+            title
+            url
+            createdAt
+            author {
+              login
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    `,
+    { org, repo },
+  );
+  return repository.issues.nodes;
+};
+
+const getPullRequests = async (repo) => {
+  const { repository } = await octokit.graphql.paginate(
+    `query paginate($cursor: String, $org: String!, $repo: String!) {
+      repository(owner: $org, name: $repo) {
+        pullRequests(first: 100, after: $cursor) {
+          nodes {
+            number
+            title
+            url
+            createdAt
+            merged
+            mergedAt
+            author {
+              login
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    `,
+    { org, repo },
+  );
+  return repository.pullRequests.nodes;
+};
+
+const getUserActivities = async () => {
+  const userActivities = {};
+
+  const addActivity = (user, activity) => {
+    userActivities[user] ??= [];
+    userActivities[user].push(activity);
+  };
+
+  for await (const response of repositoryIterator) {
+    for (const { name: repo } of response.organization.repositories.nodes) {
+      console.info(`Pulling activities for repository '${repo}'`);
+
+      const issues = await getIssues(repo);
+      console.info(`  Captured ${issues.length} issues`);
+      for (const issue of issues) {
+        addActivity(issue.author.login, {
+          type: "issue_opened",
+          title: `${org}/${repo}#${issue.number}`,
+          time: issue.createdAt,
+          link: issue.url,
+          text: issue.title,
+        });
+      }
+
+      const pulls = await getPullRequests(repo);
+      console.info(`  Captured ${pulls.length} pull requests`);
+      for (const pr of pulls) {
+        addActivity(pr.author.login, {
+          type: "pr_opened",
+          title: `${org}/${repo}#${pr.number}`,
+          time: pr.createdAt,
+          link: pr.url,
+          text: pr.title,
+        });
+
+        if (pr.merged) {
+          addActivity(pr.author.login, {
+            type: "pr_merged",
+            title: `${org}/${repo}#${pr.number}`,
+            time: pr.mergedAt,
+            link: pr.url,
+            text: pr.title,
+          });
+        }
+      }
+    }
+  }
+
+  return userActivities;
+};
+
+const getUserJson = (activities) => {
+  return JSON.stringify(
+    {
+      last_updated: new Date().toISOString(),
+      activity: activities,
+    },
+    undefined,
+    "  ",
+  );
+};
+
+const isBlacklisted = (login) => {
+  return login.includes("[bot]") || blacklistedAccounts.includes(login);
+};
+
+async function main() {
+  const userActivities = await getUserActivities();
+
+  const dataPoints = Object.values(userActivities)
+    .map((arr) => arr.length)
+    .reduce((p, v) => p + v, 0);
+  console.log(`Captured ${dataPoints} data points.`);
+
+  await mkdir(basePath, { recursive: true });
+
+  await Promise.all(
+    Object.entries(userActivities).map(async ([user, activities]) => {
+      if (isBlacklisted(user)) {
+        console.log(`Skipping for blacklisted account '${user}'`);
+        return;
+      }
+
+      const path = join(basePath, `${user}.json`);
+      console.log(`Writing activities for '${user}' to '${path}'.`);
+      await writeFile(path, getUserJson(activities), { encoding: "utf-8" });
+    }),
+  );
+
+  console.log("Completed");
+}
+
+main();

--- a/scripts/pullHistoricalGitHubActivities.js
+++ b/scripts/pullHistoricalGitHubActivities.js
@@ -168,6 +168,8 @@ const getUserJson = (activities) => {
     {
       last_updated: new Date().toISOString(),
       activity: activities,
+      open_prs: [],
+      authored_issue_and_pr: [],
     },
     undefined,
     "  ",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "data-repo", "data"]
 }


### PR DESCRIPTION
## Adds script for pulling historical data for orgs.

### How to use

Populating the data repo with historical data involves two steps:

#### Step 1: Pull historical data from GitHub

Run the following script by pointing to the data repository directory:

```bash
DATA_REPO=<data-repo-path> GITHUB_ORG=<org> GITHUB_TOKEN=<gh_pat> node scripts/pullHistoricalGitHubActivities.js
```

<img width="1284" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/c7a84abf-3228-4d59-94ad-8b64c54ef0a6">

#### Step 2: Generate markdowns for the newly added users

```bash
DATA_REPO=<data-repo-path> GITHUB_TOKEN=<gh_pat> node scripts/generateNewContributors.js
```

<img width="1379" alt="image" src="https://github.com/coronasafe/leaderboard/assets/25143503/e0427b24-08ce-400d-a284-e14b0e2c193f">



### Results

https://github.com/coronasafe/leaderboard-data/pull/36

cc: @bodhish 