### PR TITLE
Fixes allignment of search icon

### DIFF
--- a/components/filters/Search.tsx
+++ b/components/filters/Search.tsx
@@ -11,7 +11,7 @@ const Search = ({
 }) => {
   return (
     <div className={"relative rounded-md shadow-sm " + className}>
-      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+      <div className="pointer-events-none absolute top-3 flex items-center pl-3">
         <BsSearch className="text-foreground" />
       </div>
       <input


### PR DESCRIPTION
## Description
This pr fixes allignment of search icon in `Serachbar.tsx`

**Fixes : ** #435 

## Output
1. Desktop View
![image](https://github.com/coronasafe/leaderboard/assets/99136186/5bfbbbe0-6581-4543-8648-e21ff617a05b)

2. Mobile view
![image](https://github.com/coronasafe/leaderboard/assets/99136186/ab525d6f-790c-42ff-815d-db4df40f48ec)

