### PR TITLE
Slack EOD Bot: Prevent N+1 GraphQL calls to GitHub APIs for pulling reviews to avoid rate limit

### DIFF
--- a/app/api/slack-eod-bot/cron/post-update/[username]/preview/route.ts
+++ b/app/api/slack-eod-bot/cron/post-update/[username]/preview/route.ts
@@ -27,23 +27,20 @@ export async function GET(
   const readableUpdates =
     eodUdpates.length > 0
       ? `
-        Hello <@${contributor.slack}>, here are your updates for today:\n
-        ${eodUdpates.map((update) => `${update}`).join("\n\n")}\n
-        If you wish to add more updates, please reply to this message with your updates.
-        If you wish to rewrite all updates, please reply with \`clear updates\` and then specify your updates.
-    `
+Hello <@${contributor.slack}>, here are your updates for today:
+
+${eodUdpates.map((update, i) => `${i + 1}. ${update}`).join("\n")}
+
+If you wish to add more updates, please reply to this message with your updates.
+If you wish to rewrite all updates, please reply with \`clear updates\` and then specify your updates.`
       : `
-        Hello <@${contributor.slack}>, you have not specified any EOD updates for today.
-        If you wish to add updates, please reply to this message with your updates.
-    `;
+Hello <@${contributor.slack}>, you have not specified any EOD updates for today.
+If you wish to add updates, please reply to this message with your updates.`;
 
   const message = `
-        ${readableUpdates}\n
-        These updates will be sent to the EOD channel at the end of the working day along with your contribution data.
-    `
-    .split("\n")
-    .map((s) => s.trim())
-    .join("\n");
+${readableUpdates}
+These updates will be sent to the EOD channel at the end of the working day along with your contribution data.
+    `;
 
   await sendSlackMessage(contributor.slack, message);
 

--- a/app/api/slack-eod-bot/cron/post-update/[username]/route.ts
+++ b/app/api/slack-eod-bot/cron/post-update/[username]/route.ts
@@ -9,11 +9,12 @@ import { getContributorBySlug } from "@/lib/api";
 
 export const maxDuration = 300;
 
-export async function GET(
+export async function POST(
   req: NextRequest,
   { params }: { params: { username: string } },
 ) {
   const { username } = params;
+  const { reviews } = await req.json();
 
   if (
     process.env.CRON_SECRET &&
@@ -28,7 +29,7 @@ export async function GET(
   }
 
   const eodUpdatesManager = EODUpdatesManager(contributor);
-  const report = await getDailyReport(username);
+  const report = await getDailyReport(username, reviews);
   const eodUpdates = await eodUpdatesManager.get();
 
   const updates = getHumanReadableUpdates(
@@ -37,7 +38,7 @@ export async function GET(
     contributor.slack,
   );
 
-  sendSlackMessage(process.env.SLACK_EOD_BOT_CHANNEL || "", "", updates);
+  await sendSlackMessage(process.env.SLACK_EOD_BOT_CHANNEL || "", "", updates);
   eodUpdatesManager.clear();
   return new Response("OK");
 }

--- a/lib/slackbotutils.ts
+++ b/lib/slackbotutils.ts
@@ -164,11 +164,16 @@ export const sendSlackMessage = async (
   text: string,
   blocks?: any,
 ) => {
+  const resolvedChannel =
+    process.env.SLACK_EOD_BOT_DEBUG === "true"
+      ? process.env.SLACK_EOD_BOT_CHANNEL
+      : channel;
+
   const res = await fetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
     headers: slackApiHeaders,
     body: JSON.stringify({
-      channel,
+      channel: resolvedChannel,
       text,
       ...blocks,
     }),

--- a/lib/slackbotutils.ts
+++ b/lib/slackbotutils.ts
@@ -164,7 +164,7 @@ export const sendSlackMessage = async (
   text: string,
   blocks?: any,
 ) => {
-  return await fetch("https://slack.com/api/chat.postMessage", {
+  const res = await fetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
     headers: slackApiHeaders,
     body: JSON.stringify({
@@ -173,6 +173,11 @@ export const sendSlackMessage = async (
       ...blocks,
     }),
   });
+
+  const data = await res.json();
+  if (!data.ok) {
+    console.error(data);
+  }
 };
 
 export const reactToMessage = async (
@@ -180,7 +185,7 @@ export const reactToMessage = async (
   timestamp: string,
   reaction: string,
 ) => {
-  return await fetch("https://slack.com/api/reactions.add", {
+  const res = await fetch("https://slack.com/api/reactions.add", {
     method: "POST",
     headers: slackApiHeaders,
     body: JSON.stringify({
@@ -189,6 +194,11 @@ export const reactToMessage = async (
       name: reaction,
     }),
   });
+
+  const data = await res.json();
+  if (!data.ok) {
+    console.error(data);
+  }
 };
 
 const getEODUpdates = async (contributor: Contributor) => {


### PR DESCRIPTION
## Changes

- Prevent N+1 GraphQL calls to GitHub APIs for pulling reviews to avoid rate limit
- Improve logging
- Improve message formatting
- Support for using personal IM for testing/dev. purpose instead of EOD channel. Set env: `SLACK_EOD_BOT_DEBUG` to `true` and the `SLACK_EOD_BOT_CHANNEL` to your Slack user ID