### PR TITLE
Added hover Effect in Google Summer of Code label

### DIFF
--- a/app/projects/constants.ts
+++ b/app/projects/constants.ts
@@ -7,7 +7,7 @@ export type ActiveProjectLabelConfig = Record<
 
 export const ACTIVE_PROJECT_LABELS: ActiveProjectLabelConfig = {
   GSoC: {
-    className: "text-yellow-500",
+    className: "text-yellow-500 hover:bg-yellow-500 hover:text-white",
     name: "Google Summer of Code",
     shortName: "GSoC",
     ref: "https://summerofcode.withgoogle.com/",


### PR DESCRIPTION
### Add Hover Effect to Google Summer of Code Label

## Fixes Issue : #487
- Added a hover effect to the "Google Summer of Code" label.
- On hover, the background color changes to yellow and the text color turns white.

**Details:**

- Updated the `ACTIVE_PROJECT_LABELS` configuration with a new `className` to include the hover effect.
- Utilized Tailwind CSS utility classes: `hover:bg-yellow-500`, `hover:text-white`.

**Before:**
- The label had a static background and text color.

**After:**
- The background now turns yellow and the text color changes to white on hover.