### PR TITLE
refactor: TopContributorsChart component

### DIFF
--- a/apps/leaderboard-web/app/[username]/ActivityGraph.tsx
+++ b/apps/leaderboard-web/app/[username]/ActivityGraph.tsx
@@ -195,7 +195,7 @@ export default function ActivityGraph({
 
     // Filter activities by included types
     const filteredActivities = activities.filter((activity) =>
-      typesToInclude.has(activity.activity_definition_name)
+      typesToInclude.has(activity.activity_definition_name),
     );
 
     // Group by date
@@ -272,7 +272,7 @@ export default function ActivityGraph({
   const hasActiveFilters = selectedActivityTypes.size > 0;
 
   // Notify parent component of filter state changes
-  useMemo(() => {
+  useEffect(() => {
     if (onFilterChange) {
       onFilterChange({
         selectedActivityTypes,
@@ -315,7 +315,7 @@ export default function ActivityGraph({
                       className={cn(
                         "w-3 h-3 rounded-sm cursor-pointer hover:ring-2 hover:ring-primary",
                         "transition-all duration-300 ease-in-out",
-                        getLevelColor(day.level)
+                        getLevelColor(day.level),
                       )}
                       style={{
                         opacity: day.level === 0 || !isAnimating ? 1 : 0,

--- a/apps/leaderboard-web/app/[username]/ActivityTimelineItem.tsx
+++ b/apps/leaderboard-web/app/[username]/ActivityTimelineItem.tsx
@@ -32,7 +32,7 @@ export default function ActivityTimelineItem({
           )}
         </div>
         {activity.title && (
-          <p className="text-sm mb-1">
+          <div className="text-sm mb-1">
             {activity.link ? (
               <div className="flex items-center gap-1">
                 <a
@@ -48,7 +48,7 @@ export default function ActivityTimelineItem({
             ) : (
               activity.title
             )}
-          </p>
+          </div>
         )}
         {activity.text && (
           <div

--- a/apps/leaderboard-web/app/leaderboard/LeaderboardView.tsx
+++ b/apps/leaderboard-web/app/leaderboard/LeaderboardView.tsx
@@ -11,13 +11,15 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import Link from "next/link";
-import { Medal, Trophy, Filter, X } from "lucide-react";
+import { Trophy, Filter, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import ActivityTrendChart from "./ActivityTrendChart";
+import TopContributorsChart from "./TopContributorsChart";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
+import { format } from "date-fns";
 
 interface LeaderboardViewProps {
   entries: LeaderboardEntry[];
@@ -155,114 +157,111 @@ export default function LeaderboardView({
         <Trophy className="h-6 w-6 text-yellow-500" aria-label="1st place" />
       );
     if (rank === 2)
-      return <Medal className="h-6 w-6 text-gray-400" aria-label="2nd place" />;
+      return (
+        <Trophy className="h-6 w-6 text-gray-400" aria-label="2nd place" />
+      );
     if (rank === 3)
       return (
-        <Medal className="h-6 w-6 text-amber-600" aria-label="3rd place" />
+        <Trophy className="h-6 w-6 text-amber-600" aria-label="3rd place" />
       );
     return null;
   };
 
-  const periodLabels = {
-    week: "Weekly",
-    month: "Monthly",
-    year: "Yearly",
-  };
+  const formattedStartDate = format(startDate, "MMMM d, yyyy");
+  const formattedEndDate = format(endDate, "MMMM d, yyyy");
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h1 className="text-2xl font-bold mb-2">
+              {formattedStartDate} – {formattedEndDate}
+            </h1>
+            <p className="text-muted-foreground">
+              {filteredEntries.length} of {entries.length} contributors
+              {(selectedRoles.size > 0 || searchQuery) && " (filtered)"}
+            </p>
+          </div>
+
+          {/* Filters */}
+          <div className="flex items-center gap-2">
+            {/* Search Bar */}
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Search contributors..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 h-9 w-64"
+              />
+            </div>
+
+            {/* Role Filter */}
+            {availableRoles.length > 0 && (
+              <>
+                {(selectedRoles.size > 0 || searchQuery) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearFilters}
+                    className="h-9"
+                  >
+                    <X className="h-4 w-4 mr-1" />
+                    Clear
+                  </Button>
+                )}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" size="sm" className="h-9">
+                      <Filter className="h-4 w-4 mr-2" />
+                      Role
+                      {selectedRoles.size > 0 && (
+                        <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-primary text-primary-foreground">
+                          {selectedRoles.size}
+                        </span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64" align="end">
+                    <div className="space-y-4">
+                      <h4 className="font-medium text-sm">Filter by Role</h4>
+                      <div className="space-y-2 max-h-64 overflow-y-auto">
+                        {availableRoles.map((role) => (
+                          <div
+                            key={role}
+                            className="flex items-center space-x-2"
+                          >
+                            <Checkbox
+                              id={role}
+                              checked={selectedRoles.has(role)}
+                              onCheckedChange={() => toggleRole(role)}
+                            />
+                            <label
+                              htmlFor={role}
+                              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                            >
+                              {role}
+                            </label>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div className="flex gap-8">
         {/* Main Content */}
         <div className="flex-1 min-w-0">
-          {/* Header */}
-          <div className="mb-8">
-            <div className="flex items-start justify-between mb-4">
-              <div>
-                <h1 className="text-4xl font-bold mb-2">
-                  {periodLabels[period]} Leaderboard
-                </h1>
-                <p className="text-muted-foreground">
-                  {filteredEntries.length} of {entries.length} contributors
-                  {(selectedRoles.size > 0 || searchQuery) && " (filtered)"}
-                </p>
-              </div>
-
-              {/* Filters */}
-              <div className="flex items-center gap-2">
-                {/* Search Bar */}
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    type="text"
-                    placeholder="Search contributors..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="pl-9 h-9 w-64"
-                  />
-                </div>
-
-                {/* Role Filter */}
-                {availableRoles.length > 0 && (
-                  <>
-                    {(selectedRoles.size > 0 || searchQuery) && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={clearFilters}
-                        className="h-9"
-                      >
-                        <X className="h-4 w-4 mr-1" />
-                        Clear
-                      </Button>
-                    )}
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <Button variant="outline" size="sm" className="h-9">
-                          <Filter className="h-4 w-4 mr-2" />
-                          Role
-                          {selectedRoles.size > 0 && (
-                            <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-primary text-primary-foreground">
-                              {selectedRoles.size}
-                            </span>
-                          )}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-64" align="end">
-                        <div className="space-y-4">
-                          <h4 className="font-medium text-sm">
-                            Filter by Role
-                          </h4>
-                          <div className="space-y-2 max-h-64 overflow-y-auto">
-                            {availableRoles.map((role) => (
-                              <div
-                                key={role}
-                                className="flex items-center space-x-2"
-                              >
-                                <Checkbox
-                                  id={role}
-                                  checked={selectedRoles.has(role)}
-                                  onCheckedChange={() => toggleRole(role)}
-                                />
-                                <label
-                                  htmlFor={role}
-                                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                                >
-                                  {role}
-                                </label>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </PopoverContent>
-                    </Popover>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-
           {/* Period Selector */}
-          <div className="flex gap-2 mb-8 border-b">
+          <div className="flex gap-2 mb-4 border-b">
             <Link
               href="/leaderboard/week"
               className={cn(
@@ -425,62 +424,17 @@ export default function LeaderboardView({
         {Object.keys(filteredTopByActivity).length > 0 && (
           <div className="hidden xl:block w-80 shrink-0">
             <div>
-              <h2 className="text-xl font-bold mb-6">Top Contributors</h2>
-              <div className="space-y-4">
+              <h2 className="text-xl font-bold border-b pb-2 pt-1.5 mb-4">
+                Top Contributors
+              </h2>
+              <div className="space-y-6">
                 {Object.entries(filteredTopByActivity).map(
                   ([activityName, contributors]) => (
-                    <Card key={activityName} className="overflow-hidden p-0">
-                      <CardContent className="p-0">
-                        <div className="bg-muted/50 px-4 py-2.5 border-b">
-                          <h3 className="font-semibold text-sm text-foreground">
-                            {activityName}
-                          </h3>
-                        </div>
-                        <div className="p-3 space-y-2">
-                          {contributors.map((contributor, index) => (
-                            <Link
-                              key={contributor.username}
-                              href={`/${contributor.username}`}
-                              className="flex items-center gap-2.5 p-2 rounded-md hover:bg-accent transition-colors group"
-                            >
-                              <div className="flex items-center justify-center w-5 h-5 shrink-0">
-                                {index === 0 && (
-                                  <Trophy className="h-4 w-4 text-yellow-500" />
-                                )}
-                                {index === 1 && (
-                                  <Medal className="h-4 w-4 text-gray-400" />
-                                )}
-                                {index === 2 && (
-                                  <Medal className="h-4 w-4 text-amber-600" />
-                                )}
-                              </div>
-                              <Avatar className="h-9 w-9 shrink-0 border">
-                                <AvatarImage
-                                  src={contributor.avatar_url || undefined}
-                                  alt={contributor.name || contributor.username}
-                                />
-                                <AvatarFallback className="text-xs">
-                                  {(contributor.name || contributor.username)
-                                    .substring(0, 2)
-                                    .toUpperCase()}
-                                </AvatarFallback>
-                              </Avatar>
-                              <div className="flex-1 min-w-0">
-                                <p className="text-sm font-medium truncate group-hover:text-primary transition-colors leading-tight">
-                                  {contributor.name || contributor.username}
-                                </p>
-                                <p className="text-xs text-muted-foreground mt-0.5">
-                                  {contributor.count}{" "}
-                                  {contributor.count === 1
-                                    ? "activity"
-                                    : "activities"}{" "}
-                                  · {contributor.points} pts
-                                </p>
-                              </div>
-                            </Link>
-                          ))}
-                        </div>
-                      </CardContent>
+                    <Card key={activityName} className="p-4">
+                      <TopContributorsChart
+                        activityName={activityName}
+                        contributors={contributors}
+                      />
                     </Card>
                   ),
                 )}

--- a/apps/leaderboard-web/app/leaderboard/TopContributorsChart.tsx
+++ b/apps/leaderboard-web/app/leaderboard/TopContributorsChart.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import Link from "next/link";
+
+interface Contributor {
+  username: string;
+  name: string | null;
+  avatar_url: string | null;
+  points: number;
+  count: number;
+}
+
+interface TopContributorsChartProps {
+  activityName: string;
+  contributors: Contributor[];
+}
+
+export default function TopContributorsChart({
+  activityName,
+  contributors,
+}: TopContributorsChartProps) {
+  if (contributors.length === 0) return null;
+
+  const top7 = contributors.slice(0, 7);
+
+  const maxCount = Math.max(...top7.map((c) => c.count));
+
+  // Calculate nice y-axis ticks
+  const yTicks = getYTicks(maxCount);
+  const yMax = yTicks[yTicks.length - 1] || maxCount;
+
+  return (
+    <div>
+      <h3 className="font-semibold text-sm text-foreground mb-3">
+        {activityName}
+      </h3>
+      <div className="flex gap-1">
+        {/* Y-axis labels */}
+        <div className="flex flex-col justify-between text-xs text-muted-foreground pr-1 pb-8 w-6 shrink-0">
+          {[...yTicks].reverse().map((tick) => (
+            <span key={tick} className="text-right leading-none">
+              {tick}
+            </span>
+          ))}
+        </div>
+
+        {/* Bars area */}
+        <div className="flex-1 flex flex-col">
+          {/* Chart area */}
+          <div
+            className="relative flex items-end gap-1 border-b border-l border-border pl-1 pb-1"
+            style={{ height: 120 }}
+          >
+            {/* Grid lines */}
+            {yTicks.map((tick) => (
+              <div
+                key={tick}
+                className="absolute left-0 right-0 border-t border-dashed border-border/40"
+                style={{
+                  bottom: `${(tick / yMax) * 100}%`,
+                }}
+              />
+            ))}
+
+            {/* Bars */}
+            {top7.map((contributor) => {
+              const heightPercent =
+                yMax > 0 ? (contributor.count / yMax) * 100 : 0;
+
+              return (
+                <TooltipProvider key={contributor.username} delayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={`/${contributor.username}`}
+                        className="flex-1 flex items-end justify-center relative z-10"
+                        style={{ height: "100%" }}
+                      >
+                        <div
+                          className="w-full rounded-t bg-primary/70 hover:bg-primary transition-colors min-h-0.5"
+                          style={{ height: `${heightPercent}%` }}
+                        />
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="text-xs">
+                      <p className="font-medium">
+                        {contributor.name || contributor.username}
+                      </p>
+                      <p className="text-muted-foreground">
+                        {contributor.count}{" "}
+                        {contributor.count === 1 ? "activity" : "activities"} ·{" "}
+                        {contributor.points} pts
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              );
+            })}
+          </div>
+
+          {/* X-axis avatars */}
+          <div className="flex gap-1 pt-1.5 pl-1">
+            {top7.map((contributor) => (
+              <Link
+                key={contributor.username}
+                href={`/${contributor.username}`}
+                className="flex-1 flex justify-center"
+              >
+                <Avatar className="h-5 w-5 border">
+                  <AvatarImage
+                    src={contributor.avatar_url || undefined}
+                    alt={contributor.name || contributor.username}
+                  />
+                  <AvatarFallback className="text-[8px]">
+                    {(contributor.name || contributor.username)
+                      .substring(0, 2)
+                      .toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getYTicks(max: number): number[] {
+  if (max <= 0) return [0];
+  if (max <= 5) return Array.from({ length: max + 1 }, (_, i) => i);
+
+  // Pick ~4 nice ticks
+  const step = Math.ceil(max / 4);
+  const niceStep =
+    step <= 2 ? 2 : step <= 5 ? 5 : step <= 10 ? 10 : Math.ceil(step / 5) * 5;
+
+  const ticks: number[] = [];
+  for (let i = 0; i <= max; i += niceStep) {
+    ticks.push(i);
+  }
+  // Ensure the top tick covers the max
+  if (ticks[ticks.length - 1]! < max) {
+    ticks.push(ticks[ticks.length - 1]! + niceStep);
+  }
+  return ticks;
+}

--- a/apps/leaderboard-web/lib/data/loader.ts
+++ b/apps/leaderboard-web/lib/data/loader.ts
@@ -355,7 +355,13 @@ export async function getTopContributorsByActivity(
       10, // Top 10
     );
 
-    result[activitySlug] = topContributors;
+    const definition = await activityDefinitionQueries.getBySlug(
+      db,
+      activitySlug,
+    );
+    const displayName = definition?.name || activitySlug;
+
+    result[displayName] = topContributors;
   }
 
   return result;


### PR DESCRIPTION
### Description
update ActivityGraph and ActivityTimelineItem components for consistency; add TopContributorsChart component and enhance loader functions

### Related Issues
Fixes #695


## Type of Change

<!-- Check all that apply by replacing [ ] with [x] -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes, no API changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement
- [ ] 🔧 Chore/maintenance

---

## Packages Affected

<!-- Check all packages that are modified in this PR -->

- [ ] `@ohcnetwork/leaderboard-api`
- [ ] `@leaderboard/plugin-runner`
- [ ] `@leaderboard/plugin-dummy`
- [ ] `create-leaderboard-plugin`
- [ ] `create-leaderboard-data-repo`
- [ ] `leaderboard-web` (Next.js app)
- [ ] Documentation (`/docs`)
- [ ] Root configuration

---

## Quality Checklist

### Core Requirements (Mandatory)

<!-- These items are required for all PRs unless explicitly noted -->

#### Version Management

- [ ] **Changeset added**: I have run `pnpm changeset` for version-tracked packages
  - [ ] Changeset follows [semantic versioning](https://semver.org/) (patch/minor/major)
  - [ ] Changeset description is clear and user-facing
  - [ ] **OR** this PR only affects docs/config and doesn't need a changeset

> 📚 **Learn more**: Run `pnpm changeset` and follow the prompts. See [Changesets documentation](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)

#### Testing

- [ ] **Tests added/updated**: All new code has corresponding tests
  - [ ] Unit tests for business logic
  - [ ] Integration tests where applicable  
  - [ ] Edge cases and error scenarios covered
- [ ] **All tests passing**: `pnpm test` runs successfully
- [ ] **Test coverage maintained or improved**: Run `pnpm test:coverage` to verify

> 📚 **Learn more**: See [Testing Guide](../docs/testing.mdx)

#### Build & Type Safety

- [ ] **Build succeeds**: `pnpm build:packages` completes without errors
- [ ] **TypeScript types correct**: No type errors (`pnpm --filter <package> typecheck`)
- [ ] **Linting passes**: `pnpm --filter leaderboard-web lint` (for web app changes)

### Documentation

- [ ] README updated if there are user-facing changes
- [ ] Code comments added for complex logic
- [ ] JSDoc/TSDoc added for public APIs and exported functions
- [ ] Documentation site (`/docs`) updated if needed
- [ ] Migration guide included if this introduces breaking changes

> 📚 **Learn more**: See [Architecture docs](../docs/architecture.mdx) for project structure

### Plugin-Specific Requirements

<!-- Only applicable if you're creating or modifying a plugin -->

- [ ] Plugin follows the API contract defined in [`packages/api/src/types.ts`](../packages/api/src/types.ts)
- [ ] Plugin includes comprehensive tests
- [ ] Plugin has README with clear usage examples
- [ ] Plugin configuration schema is documented
- [ ] Plugin is added to the plugin documentation

> 📚 **Learn more**: See [Creating Plugins Guide](../docs/plugins/creating-plugins.mdx)

---

## Screenshots / Videos

<!-- 
For UI changes: Include before/after screenshots
For new features: Demo video or GIF is highly encouraged
For bug fixes: Screenshot showing the fix in action
-->

### Before
<!-- Screenshot or description of the bug/old behavior -->

### After
<!-- Screenshot or description of the new behavior -->

---

<!-- 
Thank you for contributing to the Leaderboard project! 🎉

Before submitting:
1. Review this checklist carefully
2. Test your changes locally with `pnpm test` and `pnpm build`
3. Ensure all required checkboxes are checked
4. Request review from appropriate maintainers

Questions? Check out our documentation or ask in discussions!
-->
