### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/packages/api/src/__tests__/queries.test.ts
+++ b/packages/api/src/__tests__/queries.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDatabase } from "../client";
-import { initializeSchema, clearAllData } from "../schema";
+import { initializeSchema } from "../schema";
 import {
   contributorQueries,
   activityDefinitionQueries,


### PR DESCRIPTION
To fix the problem, we should remove the unused symbol from the import statement so that only the actually used `initializeSchema` function is imported. This keeps behavior identical (since `clearAllData` was never used) and resolves the CodeQL warning.

Concretely, in `packages/api/src/__tests__/queries.test.ts`, on the import line that currently reads `import { initializeSchema, clearAllData } from "../schema";`, we should remove `clearAllData` from the destructuring, leaving `import { initializeSchema } from "../schema";`. No other changes, helper methods, or additional imports are required because `clearAllData` was not referenced elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._