### PR TITLE
Update container class for LeaderboardView component

### DIFF
--- a/apps/leaderboard-web/app/leaderboard/LeaderboardView.tsx
+++ b/apps/leaderboard-web/app/leaderboard/LeaderboardView.tsx
@@ -325,7 +325,7 @@ export default function LeaderboardView({
   const hasActivityBreakdown = activityDefinitions.length > 0;
 
   return (
-    <div className="container mx-auto px-4 py-6">
+    <div className="max-w-7xl container mx-auto px-4 py-6">
       {/* Period Tabs */}
       <div className="flex gap-2 mb-6 border-b justify-evenly sm:justify-start">
         {(["week", "month", "year"] as const).map((p) => (


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `LeaderboardView` component. The change constrains the maximum width of the leaderboard container to improve layout consistency on large screens.

- UI improvement:
  * Updated the root `div` in `LeaderboardView.tsx` to include `max-w-7xl`, limiting the container's maximum width for better visual appearance on wide displays.