### PR TITLE
fix: prevent filter buttons from overflowing in activity timeline card

### DIFF
--- a/apps/leaderboard-web/app/[username]/ActivityTimeline.tsx
+++ b/apps/leaderboard-web/app/[username]/ActivityTimeline.tsx
@@ -189,7 +189,7 @@ export default function ActivityTimeline({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <CardTitle>Activity Timeline</CardTitle>
             <p className="text-sm text-muted-foreground mt-1">


### PR DESCRIPTION
### Description

This PR fixes a layout issue where the filter buttons ("Date Range" and "Activity Type") in the `ActivityTimeline` card header overflow the card's boundaries and overlap with the Achievements sidebar on medium screen widths (between 768px and 1024px).

### What

- Modified the card header container class in `ActivityTimeline.tsx` to support wrapping flex items: `flex-wrap gap-4`.

### Why

On medium screen widths (768px–1024px), the Activity Timeline card becomes narrower due to the sidebar layout. The filter buttons no longer fit alongside the title, causing them to overflow the card. Allowing the header to wrap prevents this overflow while preserving the existing layout.

### How

- Updated the header container classes from: `flex items-center justify-between` with `flex flex-wrap items-center justify-between gap-4`.

### Related Issues

- Fixes #765

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Packages Affected

- [ ] `@ohcnetwork/leaderboard-api`
- [ ] `@leaderboard/plugin-runner`
- [ ] `@leaderboard/plugin-dummy`
- [ ] `create-leaderboard-plugin`
- [ ] `create-leaderboard-data-repo`
- [x] `leaderboard-web` (Next.js app)
- [ ] Documentation (`/docs`)
- [ ] Root configuration

---

## Quality Checklist

### Core Requirements (Mandatory)

#### Version Management

- [x] **OR** this PR only affects docs/config and doesn't need a changeset <!-- (or run pnpm changeset if this app package requires changesets, though next.js frontend apps typically don't require workspace changesets) -->

#### Testing

- [ ] **Tests added/updated**: All new code has corresponding tests
- [x] **All tests passing**: `pnpm test` runs successfully
- [x] **Test coverage maintained or improved**: Run `pnpm test:coverage` to verify

#### Build & Type Safety

- [x] **Build succeeds**: `pnpm build:packages` completes without errors
- [x] **TypeScript types correct**: No type errors
- [x] **Linting passes**: `pnpm --filter leaderboard-web lint`

### Documentation

- [ ] README updated if there are user-facing changes
- [ ] Code comments added for complex logic
- [ ] JSDoc/TSDoc added for public APIs and exported functions
- [ ] Documentation site (`/docs`) updated if needed
- [ ] Migration guide included if this introduces breaking changes

---

## Screenshots / Videos

### Before

<img width="730" height="507" alt="577921011-fa2c6b3f-fd53-4c39-8498-f054fe065a5c" src="https://github.com/user-attachments/assets/4fc678d3-0462-4512-a1c0-adb7a61b519f" />


The "Date Range" and "Activity Type" filter buttons in the `ActivityTimeline` card header overflow the card container on the right and overlap the Achievements sidebar on viewport widths `767 < x < 1024` .

### After

https://github.com/user-attachments/assets/be15ac3f-3bfd-42e8-9c48-aaf8cb98a965
<img width="1073" height="722" alt="Screenshot 2026-07-08 152130" src="https://github.com/user-attachments/assets/ca23ad5a-c92b-4e9e-a818-9d47cf7df310" />


The buttons wrap cleanly under the `ActivityTimeline` header title when horizontal space is limited, staying within the bounds of the card container and avoiding any overlap.
